### PR TITLE
Stop using meaningless argument passing by ref

### DIFF
--- a/src/BEAR/Resource/Renderer/HalRenderer.php
+++ b/src/BEAR/Resource/Renderer/HalRenderer.php
@@ -40,7 +40,7 @@ class HalRenderer implements RenderInterface
     /**
      * @param ResourceObject $ro
      */
-    private function valuateElements(ResourceObject &$ro)
+    private function valuateElements(ResourceObject $ro)
     {
         array_walk_recursive(
             $ro->body,


### PR DESCRIPTION
Passing argument by reference is meaningless because the argument `$ro` is an object.
