### PR TITLE
Upgrade Guzzle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,13 @@ language: php
 php:
   - 5.4
 
+env:
+  - GUZZLE_VERSION="~3.1"
+  - GUZZLE_VERSION="~3.8"
+
 before_install:
  - composer selfupdate
+ - composer require guzzle/guzzle:${GUZZLE_VERSION}
  - composer install
  - 'wget http://pecl.php.net/get/APC ; tar -xzf APC ; sh -c "cd APC-* && phpize && ./configure  && make && sudo make install" ; echo "extension=apc.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`'
  - wget http://cs.sensiolabs.org/get/php-cs-fixer.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ php:
   - 5.4
 
 env:
-  - GUZZLE_VERSION="~3.1"
-  - GUZZLE_VERSION="~3.8"
+  - GUZZLE_VERSION="3.1.*"
+  - GUZZLE_VERSION="3.8.*"
 
 before_install:
  - composer selfupdate

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "any/serializer": "*",
         "doctrine/cache": "1.*",
         "nocarrier/hal":"*",
-        "guzzle/guzzle": ">=3.3.0,<3.9.0"
+        "guzzle/guzzle": ">=3.1.0,<3.9.0"
     },
     "require-dev": {
         "facebook/xhprof": "dev-master"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "any/serializer": "*",
         "doctrine/cache": "1.*",
         "nocarrier/hal":"*",
-        "guzzle/guzzle": "3.3.*"
+        "guzzle/guzzle": ">=3.3.0,<3.9.0"
     },
     "require-dev": {
         "facebook/xhprof": "dev-master"

--- a/composer.lock
+++ b/composer.lock
@@ -3,7 +3,7 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "26b2a941882d775cad4f834d5f6e30e0",
+    "hash": "1ed239e042248150fa646afacff7a29b",
     "packages": [
         {
             "name": "any/serializer",

--- a/composer.lock
+++ b/composer.lock
@@ -3,7 +3,7 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "c54abd691fd3d8a56af741eb69b04381",
+    "hash": "26b2a941882d775cad4f834d5f6e30e0",
     "packages": [
         {
             "name": "any/serializer",
@@ -79,7 +79,7 @@
                     "homepage": "http://paul-m-jones.com"
                 },
                 {
-                    "name": "Hari KT",
+                    "name": "Hari K T",
                     "email": "kthari85@gmail.com",
                     "homepage": "http://harikt.com"
                 },
@@ -246,9 +246,10 @@
             ],
             "authors": [
                 {
-                    "name": "Jonathan Wage",
+                    "name": "Jonathan H. Wage",
                     "email": "jonwage@gmail.com",
-                    "homepage": "http://www.jwage.com/"
+                    "homepage": "http://www.jwage.com/",
+                    "role": "Creator"
                 },
                 {
                     "name": "Guilherme Blanco",
@@ -320,7 +321,7 @@
             ],
             "authors": [
                 {
-                    "name": "Jonathan H. Wage",
+                    "name": "Jonathan Wage",
                     "email": "jonwage@gmail.com",
                     "homepage": "http://www.jwage.com/",
                     "role": "Creator"
@@ -407,21 +408,21 @@
         },
         {
             "name": "guzzle/guzzle",
-            "version": "v3.3.1",
+            "version": "v3.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "0657f36c7780fb0f95cf117da3aab15cb580fb66"
+                "reference": "b4a3ce8c05e777fa18b802956d5d0e38ad338a69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/0657f36c7780fb0f95cf117da3aab15cb580fb66",
-                "reference": "0657f36c7780fb0f95cf117da3aab15cb580fb66",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b4a3ce8c05e777fa18b802956d5d0e38ad338a69",
+                "reference": "b4a3ce8c05e777fa18b802956d5d0e38ad338a69",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
-                "php": ">=5.3.2",
+                "php": ">=5.3.3",
                 "symfony/event-dispatcher": ">=2.1"
             },
             "replace": {
@@ -452,16 +453,15 @@
                 "doctrine/cache": "*",
                 "monolog/monolog": "1.*",
                 "phpunit/phpunit": "3.7.*",
+                "psr/log": "1.0.*",
                 "symfony/class-loader": "*",
-                "zend/zend-cache1": "1.12",
-                "zend/zend-log1": "1.12",
                 "zendframework/zend-cache": "2.0.*",
                 "zendframework/zend-log": "2.0.*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.8-dev"
                 }
             },
             "autoload": {
@@ -496,7 +496,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2013-03-10 23:05:38"
+            "time": "2013-12-05 23:39:20"
         },
         {
             "name": "nikic/php-parser",
@@ -609,12 +609,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/koriym/Ray.Aop.git",
-                "reference": "0b55699a42994934c1021c6f7d2d0e95a93d21d6"
+                "reference": "b8b5347d913e9af2c57916b54e5146ff078a244f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/koriym/Ray.Aop/zipball/0b55699a42994934c1021c6f7d2d0e95a93d21d6",
-                "reference": "0b55699a42994934c1021c6f7d2d0e95a93d21d6",
+                "url": "https://api.github.com/repos/koriym/Ray.Aop/zipball/b8b5347d913e9af2c57916b54e5146ff078a244f",
+                "reference": "b8b5347d913e9af2c57916b54e5146ff078a244f",
                 "shasum": ""
             },
             "require": {
@@ -648,7 +648,7 @@
                 "aop",
                 "aspect"
             ],
-            "time": "2013-12-08 01:12:28"
+            "time": "2014-01-18 11:02:51"
         },
         {
             "name": "ray/di",
@@ -656,12 +656,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/koriym/Ray.Di.git",
-                "reference": "7537685ccce68605ab708c27390b51f36234320f"
+                "reference": "eafdb09e20c58b29dd1b443e747a31f02f053cd3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/koriym/Ray.Di/zipball/7537685ccce68605ab708c27390b51f36234320f",
-                "reference": "7537685ccce68605ab708c27390b51f36234320f",
+                "url": "https://api.github.com/repos/koriym/Ray.Di/zipball/eafdb09e20c58b29dd1b443e747a31f02f053cd3",
+                "reference": "eafdb09e20c58b29dd1b443e747a31f02f053cd3",
                 "shasum": ""
             },
             "require": {
@@ -686,6 +686,7 @@
                 {
                     "name": "Akihito Koriyama",
                     "email": "akihito.koriyama@gmail.com",
+                    "homepage": "https://github.com/koriym",
                     "role": "Lead"
                 },
                 {
@@ -705,21 +706,21 @@
                 "injection",
                 "jsr"
             ],
-            "time": "2013-12-09 07:00:24"
+            "time": "2014-01-18 11:48:52"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.4.0",
+            "version": "v2.4.1",
             "target-dir": "Symfony/Component/EventDispatcher",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/EventDispatcher.git",
-                "reference": "acd1707236f6eb96fbb8d58f63d289b72ebc2f6e"
+                "reference": "e3ba42f6a70554ed05749e61b829550f6ac33601"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/acd1707236f6eb96fbb8d58f63d289b72ebc2f6e",
-                "reference": "acd1707236f6eb96fbb8d58f63d289b72ebc2f6e",
+                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/e3ba42f6a70554ed05749e61b829550f6ac33601",
+                "reference": "e3ba42f6a70554ed05749e61b829550f6ac33601",
                 "shasum": ""
             },
             "require": {
@@ -759,7 +760,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "http://symfony.com",
-            "time": "2013-12-03 14:52:22"
+            "time": "2013-12-28 08:12:03"
         }
     ],
     "packages-dev": [

--- a/src/BEAR/Resource/Adapter/Http/Guzzle.php
+++ b/src/BEAR/Resource/Adapter/Http/Guzzle.php
@@ -121,7 +121,7 @@ class Guzzle extends ResourceObject implements HttpClientInterface
     {
         /* @var $response \Guzzle\Http\Message\Response */
         $code = $response->getStatusCode();
-        $headers = $response->getHeaders()->getAll();
+        $headers = $response->getHeaders()->toArray();
         $body = $response->getBody(true);
         if (strpos($headers['Content-Type'][0], 'xml') !== false && $body) {
             $body = new \SimpleXMLElement($body);


### PR DESCRIPTION
Now, depends on guzzle/guzzle >=3.3.0, <3.9.0.

To upgrade it, change beavior of Adapter\Http\Guzzle.
Now, it returns resource object with header property with an array of
raw array using `$response->getHeaders()->toArray()`.

This fixes #30
