### PR TITLE
fix embed interceptor

### DIFF
--- a/tests/Interceptor/EmbedInterceptorTest.php
+++ b/tests/Interceptor/EmbedInterceptorTest.php
@@ -94,7 +94,7 @@ class EmbedInterceptorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param ResourceObject $resourceObject
+     * @param AbstractRequest $request
      *
      * @depends testEmbedAnnotation
      */
@@ -126,4 +126,29 @@ class EmbedInterceptorTest extends \PHPUnit_Framework_TestCase
         $invocation->proceed();
     }
 
+    public function testEmbedAnnotaionResource()
+    {
+        $request = $this->resource
+            ->get
+            ->uri('app://self/bird/sparrows')
+            ->withQuery(['id_request' => 3, 'id_object' => 5, 'id_eager_request' => 7])
+            ->request();
+
+        $this->assertSame('app://self/bird/sparrows?id_request=3&id_object=5&id_eager_request=7', $request->toUri());
+
+        /** @var $request Request */
+        $resourceObject = $request();
+        $birdRequest = $resourceObject['birdRequest'];
+        $birdObject = $resourceObject['birdObject'];
+        $eagerRequestedBird = $resourceObject['eagerRequestedBird'];
+
+        $this->assertInstanceOf('BEAR\Resource\Request', $birdRequest);
+        $this->assertSame('get app://self/bird/sparrow?id=3', $birdRequest->toUriWithMethod());
+
+        $this->assertInstanceOf('TestVendor\Sandbox\Resource\App\Bird\Sparrow', $birdObject);
+        $this->assertSame(serialize($birdObject->body), serialize(['sparrow_id' => 5]));
+
+        $this->assertInstanceOf('TestVendor\Sandbox\Resource\App\Bird\Sparrow', $eagerRequestedBird);
+        $this->assertSame(serialize($eagerRequestedBird->body), serialize(['sparrow_id' => 7]));
+    }
 }

--- a/tests/TestVendor/App/Bird/Sparrows.php
+++ b/tests/TestVendor/App/Bird/Sparrows.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace TestVendor\Sandbox\Resource\App\Bird;
+
+use BEAR\Resource\ResourceObject;
+use BEAR\Resource\Annotation\Embed;
+
+class Sparrows extends ResourceObject
+{
+    /**
+     * @Embed(rel="birdRequest", src="app://self/bird/sparrow")
+     * @Embed(rel="birdObject", src="app://self/bird/sparrow")
+     * @Embed(rel="eagerRequestedBird", src="app://self/bird/sparrow")
+     */
+    public function onGet($id_request, $id_object, $id_eager_request)
+    {
+        $this['birdRequest'] = $this['birdRequest']->addQuery(['id' => $id_request]);
+        $this['birdObject'] = $this['birdObject']->addQuery(['id' => $id_object])->eager->request();
+        $this['eagerRequestedBird'] = $this['eagerRequestedBird']->addQuery(['id' => $id_eager_request])->eager;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
Embed アノテーションの仕様( #41 )には、ResourceObject 内でEmbedされたRequestへのアクセスが行える構想のようです。

ただ、現状の実装では EmbedInterceptor で実処理の後に Request を bind しているため、以下のコードは動きません。

```
use BEAR\Resource\ResourceObject;
use BEAR\Resource\Annotation\Embed;

class Birds extends ResourceObject
{
    /**
     * @Embed(rel="bird1", src="app://self/bird/canary")
     * @Embed(rel="bird2", src="app://self/bird/sparrow{?id}")
     */
    public function onGet($id, $userId)
    {
        // ....
        $this['bird2']->withQuery(['id' => $userId];
        // or add query parameter
        $this['bird2']->addQuery(['option' => 'yes'];
    }
}
```

こちらのコードが動くように修正を行いましたので、よろしくお願いします。
