### PR TITLE
[BC BREAK] add $_SERVER for transfer

### DIFF
--- a/src/AcceptTransferInterface.php
+++ b/src/AcceptTransferInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * This file is part of the *** package
+ * This file is part of the BEAR.Resource package
  *
  * @license http://opensource.org/licenses/bsd-license.php BSD
  */
@@ -8,5 +8,11 @@ namespace BEAR\Resource;
 
 interface AcceptTransferInterface
 {
-    public function transfer(TransferInterface $responder);
+    /**
+     * Accept resource object transfer service
+     *
+     * @param TransferInterface $responder Transfer service object
+     * @param array             $server    $_SERVER
+     */
+    public function transfer(TransferInterface $responder, array $server);
 }

--- a/src/ResourceObject.php
+++ b/src/ResourceObject.php
@@ -210,9 +210,9 @@ abstract class ResourceObject implements AcceptTransferInterface, ArrayAccess, C
     /**
      * {@inheritdoc}
      */
-    public function transfer(TransferInterface $responder)
+    public function transfer(TransferInterface $responder, array $server)
     {
-        $responder($this);
+        $responder($this, $server);
     }
 
     /**

--- a/src/TransferInterface.php
+++ b/src/TransferInterface.php
@@ -8,5 +8,11 @@ namespace BEAR\Resource;
 
 interface TransferInterface
 {
-    public function __invoke(ResourceObject $resourceObject);
+    /**
+     * Transfer resource object state
+     *
+     * @param ResourceObject $resourceObject
+     * @param array          $server
+     */
+    public function __invoke(ResourceObject $resourceObject, array $server);
 }

--- a/tests/Fake/FakeResponder.php
+++ b/tests/Fake/FakeResponder.php
@@ -6,7 +6,10 @@ class FakeResponder implements TransferInterface
 {
     public $class;
 
-    public function __invoke(ResourceObject $resourceObject)
+    /**
+     * {@inheritdoc}
+     */
+    public function __invoke(ResourceObject $resourceObject, array $server)
     {
         // transfer resource object to external boundary (HTTP / File ...)
         $this->class = get_class($resourceObject);

--- a/tests/ResourceObjectTest.php
+++ b/tests/ResourceObjectTest.php
@@ -8,7 +8,7 @@ class ResourceObjectTest extends \PHPUnit_Framework_TestCase
     {
         $resourceObject = new FakeResource;
         $responder = new FakeResponder;
-        $resourceObject->transfer($responder);
+        $resourceObject->transfer($responder, []);
         $this->assertSame(FakeResource::class, $responder->class);
     }
 }


### PR DESCRIPTION
AcceptTransferInterface::transfer()
TransferInterface::transfer()

transfer() needs HTTP request information for `Etag` or `content negotiation`
