### PR TITLE
Serialized ResourceObject holds limited properties as container

### DIFF
--- a/src/ResourceObject.php
+++ b/src/ResourceObject.php
@@ -221,4 +221,11 @@ abstract class ResourceObject implements AcceptTransferInterface, ArrayAccess, C
             }
         }
     }
+
+    public function __sleep()
+    {
+        $this->evaluateBody();
+
+        return ['code', 'headers', 'body', 'view'];
+    }
 }

--- a/src/ResourceObject.php
+++ b/src/ResourceObject.php
@@ -190,11 +190,7 @@ abstract class ResourceObject implements AcceptTransferInterface, ArrayAccess, C
      */
     public function jsonSerialize()
     {
-        $body = $this->body;
-        $isTraversable = is_array($body) || $body instanceof \Traversable;
-        if ($isTraversable) {
-            return $this->evaluate($body);
-        }
+        $this->evaluateBody();
 
         return ['value' => $this->body];
     }
@@ -212,15 +208,17 @@ abstract class ResourceObject implements AcceptTransferInterface, ArrayAccess, C
      *
      * @return mixed
      */
-    private function evaluate($body)
+    private function evaluateBody()
     {
-        foreach ($body as &$value) {
+        $isTraversable = is_array($this->body) || $this->body instanceof \Traversable;
+        if (! $isTraversable) {
+            return;
+        }
+        foreach ($this->body as &$value) {
             if ($value instanceof RequestInterface) {
                 $result = $value();
                 $value = $result->body;
             }
         }
-
-        return $body;
     }
 }

--- a/src/ResourceObject.php
+++ b/src/ResourceObject.php
@@ -228,4 +228,13 @@ abstract class ResourceObject implements AcceptTransferInterface, ArrayAccess, C
 
         return ['code', 'headers', 'body', 'view'];
     }
+
+    public function __debugInfo() {
+        return [
+            'code' => $this->code,
+            'headers' => $this->headers,
+            'body' => $this->body,
+            'view' => $this->view
+        ];
+    }
 }

--- a/tests/Fake/FakeFreeze.php
+++ b/tests/Fake/FakeFreeze.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace BEAR\Resource;
+
+use BEAR\Resource\Module\ResourceModule;
+use Ray\Di\Injector;
+
+class FakeFreeze extends ResourceObject
+{
+    public $code = 201;
+    public $body = ['php' => '7'];
+
+    public $closure;
+
+    public function __construct()
+    {
+        $this->closure = function(){};
+        $module = new FakeSchemeModule(new ResourceModule('FakeVendor\Sandbox'));
+        /* @var $resource ResourceInterface */
+        $resource = (new Injector($module, $_ENV['TMP_DIR']))->getInstance(ResourceInterface::class);
+        $this['user'] = $resource->get->uri('app://self/author')->withQuery(['id' => 1])->eager->request();
+    }
+}

--- a/tests/ResourceObjectTest.php
+++ b/tests/ResourceObjectTest.php
@@ -2,6 +2,8 @@
 
 namespace BEAR\Resource;
 
+use FakeVendor\Sandbox\Resource\App\Author;
+
 class ResourceObjectTest extends \PHPUnit_Framework_TestCase
 {
     public function testTransfer()
@@ -10,5 +12,19 @@ class ResourceObjectTest extends \PHPUnit_Framework_TestCase
         $responder = new FakeResponder;
         $resourceObject->transfer($responder, []);
         $this->assertSame(FakeResource::class, $responder->class);
+    }
+
+    public function testSerialize()
+    {
+        $ro = new FakeFreeze;
+        $ro->uri = new Uri('app://self/freeze');
+        $serialized = serialize($ro);
+        $this->assertInternalType('string', $serialized);
+        $expected = 'app://self/freeze';
+        $this->assertSame($expected, $ro->uri);
+        $expected = 'O:24:"BEAR\Resource\FakeFreeze":5:{s:3:"uri";s:17:"app://self/freeze";s:4:"code";i:201;s:7:"headers";a:0:{}s:4:"body";a:2:{s:3:"php";s:1:"7";s:4:"user";O:38:"FakeVendor\Sandbox\Resource\App\Author":5:{s:3:"uri";s:22:"app://self/author?id=1";s:4:"code";i:200;s:7:"headers";a:0:{}s:4:"body";a:3:{s:4:"name";s:6:"Aramis";s:3:"age";i:16;s:7:"blog_id";i:12;}s:4:"view";N;}}s:4:"view";N;}';
+        $this->assertSame($expected, $serialized);
+        $resourceObject = unserialize($serialized);
+        $this->assertInstanceOf(Author::class, $resourceObject['user']);
     }
 }


### PR DESCRIPTION
Serialized `ResourceObject` holds [`uri`, `code`, `headers`, `body` and `view`]. 

Rest of properties are removed.
