### PR TITLE
href() in ResourceObject

### DIFF
--- a/src/EmbedInterceptor.php
+++ b/src/EmbedInterceptor.php
@@ -31,7 +31,7 @@ final class EmbedInterceptor implements MethodInterceptor
      */
     public function __construct(ResourceInterface $resource, Reader $reader)
     {
-        $this->resource = $resource;
+        $this->resource = clone $resource;
         $this->reader = $reader;
     }
 

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -117,7 +117,7 @@ final class Resource implements ResourceInterface
     public function href($rel, array $query = [])
     {
         list($method, $uri) = $this->anchor->href($rel, $this->request, $query);
-        $target = $this->{$method}->uri($uri)->withQuery($query)->eager->request();
+        $target = $this->{$method}->uri($uri)->addQuery($query)->eager->request();
 
         return $target;
     }

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -117,7 +117,7 @@ final class Resource implements ResourceInterface
     public function href($rel, array $query = [])
     {
         list($method, $uri) = $this->anchor->href($rel, $this->request, $query);
-        $target = $this->{$method}->uri($uri)->eager->request();
+        $target = $this->{$method}->uri($uri)->withQuery($query)->eager->request();
 
         return $target;
     }

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/Href/Hasembed.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/Href/Hasembed.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace FakeVendor\Sandbox\Resource\App\Href;
+
+use BEAR\Resource\Annotation\Link;
+use BEAR\Resource\ResourceInterface;
+use BEAR\Resource\ResourceObject;
+use BEAR\Resource\Annotation\Embed;
+
+class Hasembed extends ResourceObject
+{
+    private $resource;
+
+    public function __construct(ResourceInterface $resource)
+    {
+        $this->resource = $resource;
+    }
+
+    /**
+     * @Embed(rel="bird1", src="app://self/bird/canary")
+     * @Link(rel="next", href="app://self/href/target?id={id}")
+     */
+    public function onGet($id)
+    {
+        $this['next'] = $this->resource->href('next', ['id' => $id]);
+
+        return $this;
+    }
+}

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/Href/Origin.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/Href/Origin.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace FakeVendor\Sandbox\Resource\App\Href;
+
+use BEAR\Resource\Annotation\Link;
+use BEAR\Resource\ResourceInterface;
+use BEAR\Resource\ResourceObject;
+
+class Origin extends ResourceObject
+{
+    private $resource;
+
+    public function __construct(ResourceInterface $resource)
+    {
+        $this->resource = $resource;
+    }
+
+    /**
+     * @Link(rel="next", href="app://self/href/target?id={id}")
+     */
+    public function onGet($id)
+    {
+        $this['next'] = $this->resource->href('next', ['id' => $id]);
+
+        return $this;
+    }
+}

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/Href/Target.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/Href/Target.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace FakeVendor\Sandbox\Resource\App\Href;
+
+use BEAR\Resource\ResourceObject;
+
+class Target extends ResourceObject
+{
+    public function onGet($id)
+    {
+        $this['id'] = $id;
+
+        return $this;
+    }
+}

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -7,6 +7,10 @@ use BEAR\Resource\Module\ResourceModule;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Cache\ArrayCache;
 use FakeVendor\Sandbox\Resource\App\Blog;
+use FakeVendor\Sandbox\Resource\App\Href\Embed;
+use FakeVendor\Sandbox\Resource\App\Href\Hasembed;
+use FakeVendor\Sandbox\Resource\App\Href\Origin;
+use FakeVendor\Sandbox\Resource\App\Href\Target;
 use FakeVendor\Sandbox\Resource\Page\Index;
 use Ray\Di\EmptyModule;
 use Ray\Di\Injector;
@@ -89,6 +93,24 @@ class ResourceTest extends \PHPUnit_Framework_TestCase
         $this->resource->get->uri('app://self/author')->withQuery(['id' => 1])->eager->request();
         $blog = $this->resource->href('blog');
         $this->assertInstanceOf(Blog::class, $blog);
+    }
+
+    public function testHrefInResourceObject()
+    {
+        $origin = $this->resource->get->uri('app://self/href/origin')->withQuery(['id' => 1])->eager->request();
+        $this->assertInstanceOf(Origin::class, $origin);
+        $this->assertInstanceOf(Target::class, $origin['next']);
+        $next = $origin['next'];
+        $this->assertSame($next['id'], 1);
+    }
+
+    public function testHrefInResourceObjectHasEmbed()
+    {
+        $origin = $this->resource->get->uri('app://self/href/hasembed')->withQuery(['id' => 1])->eager->request();
+        $this->assertInstanceOf(Hasembed::class, $origin);
+        $this->assertInstanceOf(Target::class, $origin['next']);
+        $next = $origin['next'];
+        $this->assertSame($next['id'], 1);
     }
 
     public function testLinkSelf()


### PR DESCRIPTION
 `href()` can invoke hyper linked resource with `@Link` annotated  resource.

``` php
class Origin extends ResourceObject
{
    private $resource;

    public function __construct(ResourceInterface $resource)
    {
        $this->resource = $resource;
    }

    /**
     * @Link(rel="next", href="app://self/href/target?id={id}" method="put")
     */
    public function onGet($id)
    {
        $this['next'] = $this->resource->href('next', ['id' => $id]);

        return $this;
    }
}
```
