### PR TITLE
dashed URI to camel class name

### DIFF
--- a/src/AppAdapter.php
+++ b/src/AppAdapter.php
@@ -6,6 +6,8 @@
  */
 namespace BEAR\Resource;
 
+use BEAR\Resource\Exception\ResourceNotFoundException;
+use Ray\Di\Exception\Unbound;
 use Ray\Di\InjectorInterface;
 
 final class AppAdapter implements AdapterInterface
@@ -53,7 +55,15 @@ final class AppAdapter implements AdapterInterface
             $this->path,
             str_replace('/', '\\', ucwords($uri->scheme) . str_replace('-', '', ucwords($uri->path, '/-')))
         );
-        $instance = $this->injector->getInstance($class);
+        try {
+            $instance = $this->injector->getInstance($class);
+        } catch (Unbound $e) {
+            $unboundClass = $e->getMessage();
+            if  ($unboundClass === "{$class}-") {
+                throw new ResourceNotFoundException($uri, 404, $e);
+            }
+            throw $e;
+        }
 
         return $instance;
     }

--- a/src/AppAdapter.php
+++ b/src/AppAdapter.php
@@ -50,7 +50,7 @@ final class AppAdapter implements AdapterInterface
             $uri->path .= 'index';
         }
         // dirty hack for hhvm bug https://github.com/facebook/hhvm/issues/6368
-        $path = ! defined('HHVM') ? str_replace('-', '', ucwords($uri->path, '/-')) : str_replace(' ', '\\', substr(ucwords(str_replace('/', ' ', ' ' . str_replace(' ', '', ucwords(str_replace('-', ' ', $uri->path))))), 1));
+        $path = ! defined('HHVM_VERSION') ? str_replace('-', '', ucwords($uri->path, '/-')) : str_replace(' ', '\\', substr(ucwords(str_replace('/', ' ', ' ' . str_replace(' ', '', ucwords(str_replace('-', ' ', $uri->path))))), 1));
         $class = sprintf(
             '%s%s\Resource\%s',
             $this->namespace,

--- a/src/AppAdapter.php
+++ b/src/AppAdapter.php
@@ -49,11 +49,12 @@ final class AppAdapter implements AdapterInterface
         if (substr($uri->path, -1) === '/') {
             $uri->path .= 'index';
         }
+        $path = str_replace(' ', '', ucwords(str_replace('-', ' ', $uri->path))); // dash to camel case
         $class = sprintf(
             '%s%s\Resource\%s',
             $this->namespace,
             $this->path,
-            str_replace('/', '\\', ucwords($uri->scheme) . str_replace('-', '', ucwords($uri->path, '/-')))
+            str_replace('/', '\\', ucwords($uri->scheme) . str_replace(' ', '\\', substr(ucwords(str_replace('/', ' ', ' ' . $path)), 1))) // slash-delimiter camel case
         );
         try {
             $instance = $this->injector->getInstance($class);

--- a/src/AppAdapter.php
+++ b/src/AppAdapter.php
@@ -44,7 +44,12 @@ final class AppAdapter implements AdapterInterface
      */
     public function get(AbstractUri $uri)
     {
-        $class = $this->namespace . $this->path . '\Resource' . str_replace(' ', '\\', ucwords(str_replace('/', ' ', ' ' . $uri->scheme . $uri->path)));
+        if (substr($uri->path, -1) === '/') {
+            $uri->path .= 'index';
+        }
+        $schemePath = ucwords($uri->scheme) . str_replace('-', '', ucwords($uri->path, '/-'));
+        $namespace = str_replace('/', '\\', $schemePath);
+        $class = sprintf('%s%s\Resource\%s', $this->namespace, $this->path, $namespace);
         $instance = $this->injector->getInstance($class);
 
         return $instance;

--- a/src/AppAdapter.php
+++ b/src/AppAdapter.php
@@ -49,12 +49,13 @@ final class AppAdapter implements AdapterInterface
         if (substr($uri->path, -1) === '/') {
             $uri->path .= 'index';
         }
-        $path = str_replace(' ', '', ucwords(str_replace('-', ' ', $uri->path))); // dash to camel case
+        // dirty hack for hhvm bug https://github.com/facebook/hhvm/issues/6368
+        $path = ! defined('HHVM') ? str_replace('-', '', ucwords($uri->path, '/-')) : str_replace(' ', '\\', substr(ucwords(str_replace('/', ' ', ' ' . str_replace(' ', '', ucwords(str_replace('-', ' ', $uri->path))))), 1));
         $class = sprintf(
             '%s%s\Resource\%s',
             $this->namespace,
             $this->path,
-            str_replace('/', '\\', ucwords($uri->scheme) . str_replace(' ', '\\', substr(ucwords(str_replace('/', ' ', ' ' . $path)), 1))) // slash-delimiter camel case
+            str_replace('/', '\\', ucwords($uri->scheme) . $path)
         );
         try {
             $instance = $this->injector->getInstance($class);

--- a/src/AppAdapter.php
+++ b/src/AppAdapter.php
@@ -47,9 +47,12 @@ final class AppAdapter implements AdapterInterface
         if (substr($uri->path, -1) === '/') {
             $uri->path .= 'index';
         }
-        $schemePath = ucwords($uri->scheme) . str_replace('-', '', ucwords($uri->path, '/-'));
-        $namespace = str_replace('/', '\\', $schemePath);
-        $class = sprintf('%s%s\Resource\%s', $this->namespace, $this->path, $namespace);
+        $class = sprintf(
+            '%s%s\Resource\%s',
+            $this->namespace,
+            $this->path,
+            str_replace('/', '\\', ucwords($uri->scheme) . str_replace('-', '', ucwords($uri->path, '/-')))
+        );
         $instance = $this->injector->getInstance($class);
 
         return $instance;

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -49,11 +49,7 @@ final class Factory implements FactoryInterface
             $uri = new Uri($uri);
         }
         $adapter = $this->scheme->getAdapter($uri);
-        try {
-            $resourceObject = $adapter->get($uri);
-        } catch (Unbound $e) {
-            throw new ResourceNotFoundException($uri, 404, $e);
-        }
+        $resourceObject = $adapter->get($uri);
 
         return $resourceObject;
     }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -52,25 +52,9 @@ final class Factory implements FactoryInterface
         try {
             $resourceObject = $adapter->get($uri);
         } catch (Unbound $e) {
-            $resourceObject = $this->retryWithIndexSuffix($e, $uri);
+            throw new ResourceNotFoundException($uri, 404, $e);
         }
 
         return $resourceObject;
-    }
-
-    /**
-     * @param Unbound $e
-     * @param Uri     $uri
-     *
-     * @return ResourceObject
-     */
-    private function retryWithIndexSuffix(Unbound $e, Uri $uri)
-    {
-        if (substr($uri->path, -1) !== '/' || substr($uri->path, -6) === '/index') {
-            throw new ResourceNotFoundException($uri, 404, $e);
-        }
-        $uri .= 'index';
-
-        return $this->newInstance((string) $uri);
     }
 }

--- a/src/SchemeCollectionInterface.php
+++ b/src/SchemeCollectionInterface.php
@@ -34,4 +34,13 @@ interface SchemeCollectionInterface
      * @return $this
      */
     public function toAdapter(AdapterInterface $adapter);
+
+    /**
+     * Return resource adapter
+     *
+     * @param AbstractUri $uri
+     *
+     * @return AdapterInterface
+     */
+    public function getAdapter(AbstractUri $uri);
 }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -9,6 +9,7 @@ use FakeVendor\Sandbox\Resource\App\Factory\News;
 use FakeVendor\Sandbox\Resource\Page\HelloWorld;
 use FakeVendor\Sandbox\Resource\Page\Index as IndexPage;
 use FakeVendor\Sandbox\Resource\Page\News as PageNews;
+use Ray\Di\Exception\Unbound;
 use Ray\Di\Injector;
 
 class FactoryTest extends \PHPUnit_Framework_TestCase
@@ -81,6 +82,12 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException(ResourceNotFoundException::class);
         $this->factory->newInstance('page://self/not_found_XXXX');
+    }
+
+    public function testUnbound()
+    {
+        $this->setExpectedException(Unbound::class);
+        $instance = $this->factory->newInstance('page://self/unbound');
     }
 
     public function testIndexSuffix()

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -6,6 +6,7 @@ use BEAR\Resource\Exception\ResourceNotFoundException;
 use BEAR\Resource\Exception\SchemeException;
 use BEAR\Resource\Exception\UriException;
 use FakeVendor\Sandbox\Resource\App\Factory\News;
+use FakeVendor\Sandbox\Resource\Page\HelloWorld;
 use FakeVendor\Sandbox\Resource\Page\Index as IndexPage;
 use FakeVendor\Sandbox\Resource\Page\News as PageNews;
 use Ray\Di\Injector;
@@ -86,5 +87,11 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     {
         $instance = $this->factory->newInstance('page://self/');
         $this->assertInstanceOf(IndexPage::class, $instance);
+    }
+
+    public function testDash()
+    {
+        $instance = $this->factory->newInstance('page://self/hello-world');
+        $this->assertInstanceOf(HelloWorld::class, $instance);
     }
 }

--- a/tests/Fake/FakeVendor/Sandbox/Resource/Page/HelloWorld.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/Page/HelloWorld.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace FakeVendor\Sandbox\Resource\Page;
+
+use BEAR\Resource\ResourceObject;
+
+class HelloWorld extends ResourceObject
+{
+}

--- a/tests/Fake/FakeVendor/Sandbox/Resource/Page/Unbound.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/Page/Unbound.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace FakeVendor\Sandbox\Resource\Page;
+
+use BEAR\Resource\ResourceObject;
+use BEAR\Resource\UnboundInterface;
+
+class Unbound extends ResourceObject
+{
+    public function __construct(UnboundInterface $missing)
+    {
+    }
+}

--- a/tests/Fake/UnboundInterface.php
+++ b/tests/Fake/UnboundInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace BEAR\Resource;
+
+/**
+ * No implementation interface
+ */
+interface UnboundInterface
+{
+}


### PR DESCRIPTION
- Dashed URI is supported.
  - `page://self/hello-world` is mapped to `Vendor\Project\Resource\Page\HelloWorld`
- `Unbound` exception is thrown when dependency is not given for resource object 

ダッシュ（ハイフン）付きのURIがサポートされます。
 `ResoruceObject`が依存解決できない場合はこれまでの`ResourceNotFoundException`から`Unbound`例外が投げられるようになりました。
