### PR TITLE
Resource class to be changed to propagate request method to AppAdapter.

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -96,6 +96,7 @@ final class Resource implements ResourceInterface
     {
         if (is_string($uri)) {
             $uri = new Uri($uri);
+            $uri->method = $this->method;
         }
         $resourceObject = $this->newInstance($uri);
         $resourceObject->uri = $uri;


### PR DESCRIPTION
前提：リソースクラスが外部の Web API にリクエストするような場合、リソースの URI と Web API の URI の構造を統一した方が管理が楽になります。

現状：AppAdapter はあくまでもルーターが解釈した URI に沿ったリソースしか返すことができませんので、例えば `/user/123/comments` のような URI は Aura ルーターなどで `$router->add('/user/comments', '/user/{user_id}/comments')->addValues(['path' => '/user/comments']);` と定義して URI からクエリを分離する必要があります。
BEAR アプリケーション内部で処理を完結する場合は問題ありませんが、外部に”そのままの” URI でリクエストしたい場合、前述の方法で分離した URI を元の URI に再結合する必要があります。

対策：ルーターではなくその先の `AppAdapter` クラスに URI とリソースクラスの対応表を定義することで、ハイパーリンクの構造を保ちつつ前述のような URI へのリクエストを受け付けます。

AppAdapter の実装例

```
<?php
namespace MyVendor\MyPackage\Resource;

use BEAR\Resource\AdapterInterface;
use BEAR\Resource\AbstractUri;
use Ray\Di\InjectorInterface;

final class AppAdapter implements AdapterInterface
{
    /**
     * @var InjectorInterface
     */
    private $injector;

    /**
     * Resource adapter namespace
     *
     * @var string
     */
    private $namespace;

    /**
     * Resource adapter path
     *
     * @var string
     */
    private $path;

    private $patterns = [
        '/user/[0-9]+/comments' => 'User/Comment',
    ];

    /**
     * @param InjectorInterface $injector  Application dependency injector
     * @param string            $namespace Resource adapter namespace
     */
    public function __construct(InjectorInterface $injector, $namespace)
    {
        $this->injector = $injector;
        $this->namespace = $namespace;
    }

    /**
     * {@inheritdoc}
     */
    public function get(AbstractUri $uri)
    {
        foreach ($this->patterns as $regex => $resource) {
            if (!preg_match(sprintf('!^%s\z!', $regex), $uri->path)) {
                continue;
            }
            $class = sprintf('%s%s\Resource\%s\%s', $this->namespace, $this->path, ucfirst($uri->scheme), $resource);
            $instance = $this->injector->getInstance($class);
            return $instance;
        }

        $class = $this->namespace . $this->path . '\Resource' . str_replace(' ', '\\', ucwords(str_replace('/', ' ', ' ' . $uri->scheme . $uri->path)));
        $instance = $this->injector->getInstance($class);

        return $instance;
    }
}
```

このような場合、例えば `GET /user/123` はあるけれど `POST /user/123` は存在しない、というような状況が考えられますが、`AppAdapter` に渡された `$uri` にはリソースクラスのリクエストメソッドがなんであるかが渡っていないため、`AppAdapter` にリクエストメソッドに応じた処理を実装することができません。

これの対策として、`$uri->method` にリクエストメソッドを渡す事を提案します。
