### PR TITLE
Keep resource client method isolated

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -122,12 +122,13 @@ final class Resource implements ResourceInterface
         if (is_string($uri)) {
             $uri = new Uri($uri);
         }
+        $method = $this->method;
         $resourceObject = $this->newInstance($uri);
         $resourceObject->uri = $uri;
         $this->request = new Request(
             $this->invoker,
             $resourceObject,
-            $this->method,
+            $method,
             $uri->query,
             [],
             $this->linker

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/Holder.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/Holder.php
@@ -1,0 +1,18 @@
+<?php
+namespace FakeVendor\Sandbox\Resource\App;
+
+use BEAR\Resource\ResourceInterface;
+use BEAR\Resource\ResourceObject;
+
+class Holder extends ResourceObject
+{
+    public function __construct(ResourceInterface $resource)
+    {
+        $resource->get->uri('app://self/author?id=1')->eager->request();
+    }
+
+    public function onPost()
+    {
+        return true;
+    }
+}

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -157,4 +157,10 @@ class ResourceTest extends \PHPUnit_Framework_TestCase
 ';
         $this->assertSame($expected, (string) $user);
     }
+
+    public function testConstructorHasAnotherResourceRequest()
+    {
+        $body = $this->resource->post->uri('app://self/holder')->eager->request()->body;
+        $this->assertSame(true, $body);
+    }
 }


### PR DESCRIPTION
```php
class Holder extends ResourceObject
{
    public function __construct(ResourceInterface $resource)
    {
        $resource->get->uri('app://self/author?id=1')->eager->request();
    }
    public function onPost()
    {
        return true;
    }
}
```

When constructor has another resource request, request method was shared with two resource request client because it is injected as a singleton. This PR fix the issue.

This issue is appeared when the form which has resource request in `init()` injected resource client. 