### PR TITLE
@ResourceParam with templated uri

### DIFF
--- a/src-deprecated/ParamHandlerInterface.php
+++ b/src-deprecated/ParamHandlerInterface.php
@@ -6,6 +6,9 @@
  */
 namespace BEAR\Resource;
 
+/**
+ * @deprecated
+ */
 interface ParamHandlerInterface
 {
     /**

--- a/src-deprecated/ResourceParamHandler.php
+++ b/src-deprecated/ResourceParamHandler.php
@@ -10,6 +10,9 @@ use BEAR\Resource\Annotation\ResourceParam;
 use Doctrine\Common\Annotations\Reader;
 use Ray\Di\InjectorInterface;
 
+/**
+ * @deprecated
+ */
 class ResourceParamHandler implements ParamHandlerInterface
 {
     /**

--- a/src-deprecated/VoidParamHandler.php
+++ b/src-deprecated/VoidParamHandler.php
@@ -9,6 +9,9 @@ namespace BEAR\Resource;
 use BEAR\Resource\Exception\ParameterException;
 use Ray\Aop\WeavedInterface;
 
+/**
+ * @deprecated
+ */
 class VoidParamHandler implements ParamHandlerInterface
 {
     /**

--- a/src/Annotation/ResourceParam.php
+++ b/src/Annotation/ResourceParam.php
@@ -21,4 +21,9 @@ final class ResourceParam
      * @var string
      */
     public $uri;
+
+    /**
+     * @var bool
+     */
+    public $templated = false;
 }

--- a/src/Module/ResourceClientModule.php
+++ b/src/Module/ResourceClientModule.php
@@ -18,6 +18,8 @@ use BEAR\Resource\LinkerInterface;
 use BEAR\Resource\NamedParameter;
 use BEAR\Resource\NamedParameterInterface;
 use BEAR\Resource\OptionsRenderer;
+use BEAR\Resource\ParameterHandler;
+use BEAR\Resource\ParameterHandlerInterface;
 use BEAR\Resource\ParamHandlerInterface;
 use BEAR\Resource\RenderInterface;
 use BEAR\Resource\Resource;
@@ -50,7 +52,8 @@ class ResourceClientModule extends AbstractModule
         $this->bind(NamedParameterInterface::class)->to(NamedParameter::class);
         $this->bind(RenderInterface::class)->to(JsonRenderer::class)->in(Scope::SINGLETON);
         $this->bind(Cache::class)->to(ArrayCache::class);
-        $this->bind(ParamHandlerInterface::class)->to(ResourceParamHandler::class);
         $this->bind(RenderInterface::class)->annotatedWith('options')->to(OptionsRenderer::class);
+        $this->bind(ParameterHandlerInterface::class)->to(ParameterHandler::class);
+        $this->bind(ParamHandlerInterface::class)->to(ResourceParamHandler::class);
     }
 }

--- a/src/NamedParameter.php
+++ b/src/NamedParameter.php
@@ -16,11 +16,11 @@ final class NamedParameter implements NamedParameterInterface
     private $cache;
 
     /**
-     * @var ParamHandlerInterface
+     * @var ParameterHandlerInterface
      */
     private $handler;
 
-    public function __construct(Cache $cache, ParamHandlerInterface $handler)
+    public function __construct(Cache $cache, ParameterHandlerInterface $handler)
     {
         $this->cache = $cache;
         $this->handler = $handler;
@@ -67,7 +67,7 @@ final class NamedParameter implements NamedParameterInterface
             $value = array_key_exists($name, $query) ? $query[$name] : $defaultValue;
             if ($value instanceof Param) {
                 $parameter = new \ReflectionParameter([$value->class, $value->method], $value->param);
-                $value = $this->handler->handle($parameter);
+                $value = $this->handler->handle($parameter, $query);
             }
             $parameters[] = $value;
         }

--- a/src/ParameterHandler.php
+++ b/src/ParameterHandler.php
@@ -47,7 +47,7 @@ class ParameterHandler implements ParameterHandlerInterface
                 return $this->getResourceParam($annotation, $query);
             }
         }
-        (new VoidParamHandler)->handle($parameter);
+        (new VoidParameterHandler)->handle($parameter, $query);
     }
 
     /**

--- a/src/ParameterHandler.php
+++ b/src/ParameterHandler.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Resource;
+
+use BEAR\Resource\Annotation\ResourceParam;
+use Doctrine\Common\Annotations\Reader;
+use Ray\Di\InjectorInterface;
+
+/**
+ * Resource parameter handler
+ */
+class ParameterHandler implements ParameterHandlerInterface
+{
+    /**
+     * @var Reader
+     */
+    private $reader;
+
+    /**
+     * @var InjectorInterface
+     */
+    private $injector;
+
+    public function __construct(Reader $reader, InjectorInterface $injector)
+    {
+        $this->reader = $reader;
+        $this->injector = $injector;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \BEAR\Resource\Exception\ParameterException
+     */
+    public function handle(\ReflectionParameter $parameter, array $query)
+    {
+        $func = $parameter->getDeclaringFunction();
+        $method = new \ReflectionMethod($parameter->getDeclaringClass()->name, $func->name);
+        $parameter->getDeclaringFunction()->name;
+        $annotations = $this->reader->getMethodAnnotations($method);
+        foreach ($annotations as $annotation) {
+            if ($annotation instanceof ResourceParam && $annotation->param === $parameter->name) {
+                return $this->getResourceParam($annotation, $query);
+            }
+        }
+        (new VoidParamHandler)->handle($parameter);
+    }
+
+    /**
+     * @param ResourceParam $resourceParam
+     * @param array         $query
+     *
+     * @return mixed
+     */
+    private function getResourceParam(ResourceParam $resourceParam, array $query)
+    {
+        $uri = $resourceParam->templated === true ? uri_template($resourceParam->uri, $query) : $resourceParam->uri;
+        $resource = $this->injector->getInstance(ResourceInterface::class);
+        $resourceResult = $resource->get->uri($uri)->eager->request();
+        $fragment = parse_url($uri, PHP_URL_FRAGMENT);
+
+        return $resourceResult[$fragment];
+    }
+}

--- a/src/ParameterHandlerInterface.php
+++ b/src/ParameterHandlerInterface.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Resource;
+
+interface ParameterHandlerInterface
+{
+    /**
+     * Handle insufficient parameter
+     *
+     * @param \ReflectionParameter $parameter
+     * @param array                $query
+     *
+     * @return mixed
+     */
+    public function handle(\ReflectionParameter $parameter, array $query);
+}

--- a/src/VoidParameterHandler.php
+++ b/src/VoidParameterHandler.php
@@ -18,6 +18,7 @@ class VoidParameterHandler implements ParameterHandlerInterface
      */
     public function handle(\ReflectionParameter $parameter, array $query)
     {
+        unset($query);
         $class = $parameter->getDeclaringClass();
         $className = $class->implementsInterface(WeavedInterface::class) ? $class->getParentClass()->getName() : $class->name;
         $method = $parameter->getDeclaringFunction()->name;

--- a/src/VoidParameterHandler.php
+++ b/src/VoidParameterHandler.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Resource;
+
+use BEAR\Resource\Exception\ParameterException;
+use Ray\Aop\WeavedInterface;
+
+class VoidParameterHandler implements ParameterHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws ParameterException
+     */
+    public function handle(\ReflectionParameter $parameter, array $query)
+    {
+        $class = $parameter->getDeclaringClass();
+        $className = $class->implementsInterface(WeavedInterface::class) ? $class->getParentClass()->getName() : $class->name;
+        $method = $parameter->getDeclaringFunction()->name;
+        $msg = sprintf('$%s in %s::%s()', $parameter->name, $className, $method);
+
+        throw new ParameterException($msg, Code::BAD_REQUEST);
+    }
+}

--- a/tests-php7/OptionsTest.php
+++ b/tests-php7/OptionsTest.php
@@ -29,7 +29,7 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->invoker = new Invoker(new NamedParameter(new ArrayCache, new VoidParamHandler), new OptionsRenderer(new AnnotationReader));
+        $this->invoker = new Invoker(new NamedParameter(new ArrayCache, new VoidParameterHandler), new OptionsRenderer(new AnnotationReader));
     }
 
     public function testOptionsMethod()

--- a/tests/AnchorTest.php
+++ b/tests/AnchorTest.php
@@ -26,7 +26,7 @@ class AnchorTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         parent::setUp();
-        $invoker = new Invoker(new NamedParameter(new ArrayCache, new VoidParamHandler), new OptionsRenderer(new AnnotationReader()));
+        $invoker = new Invoker(new NamedParameter(new ArrayCache, new VoidParameterHandler), new OptionsRenderer(new AnnotationReader()));
         $author = new Author;
         $author->onGet(1);
         $this->request = new Request($invoker, $author, Request::GET, ['id' => 1]);

--- a/tests/Fake/FakeRoot.php
+++ b/tests/Fake/FakeRoot.php
@@ -11,7 +11,7 @@ class FakeRoot extends ResourceObject
     {
         $this['one'] = 1;
         $this['two'] = new Request(
-            new Invoker(new NamedParameter(new ArrayCache, new VoidParamHandler), new OptionsRenderer(new AnnotationReader)),
+            new Invoker(new NamedParameter(new ArrayCache, new VoidParameterHandler), new OptionsRenderer(new AnnotationReader)),
             new FakeChild
         );
 

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/Rparam/Greeting.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/Rparam/Greeting.php
@@ -22,11 +22,11 @@ class Greeting extends ResourceObject
     }
 
     /**
-     * @ResourceParam(param="name", uri="app://self/rparam/login{?name}#nickname", templated=true)
+     * @ResourceParam(param="id", uri="app://self/rparam/login{?name}#nickname", templated=true)
      */
-    public function onPost($name)
+    public function onPost($id, $name)
     {
-        $this['name'] = $name;
+        $this['id'] = $id;
 
         return $this;
     }

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/Rparam/Greeting.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/Rparam/Greeting.php
@@ -10,7 +10,7 @@ class Greeting extends ResourceObject
     /**
      * @ResourceParam(param="name", uri="app://self/rparam/login#nickname")
      */
-    public function onGet($name)
+    public function onGet($name = 'sunday')
     {
         $this['name'] = $name;
 
@@ -19,5 +19,15 @@ class Greeting extends ResourceObject
 
     public function onPut($name)
     {
+    }
+
+    /**
+     * @ResourceParam(param="name", uri="app://self/rparam/login{?name}#nickname", templated=true)
+     */
+    public function onPost($name)
+    {
+        $this['name'] = $name;
+
+        return $this;
     }
 }

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/Rparam/Login.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/Rparam/Login.php
@@ -6,9 +6,9 @@ use BEAR\Resource\ResourceObject;
 
 class Login extends ResourceObject
 {
-    public function onGet()
+    public function onGet($name = 'sunday')
     {
-        $this['nickname'] = 'sunday';
+        $this['nickname'] = 'login:' . $name;
 
         return $this;
     }

--- a/tests/InvokerTest.php
+++ b/tests/InvokerTest.php
@@ -38,7 +38,7 @@ class InvokerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->invoker = new Invoker(new NamedParameter(new ArrayCache, new VoidParamHandler), new OptionsRenderer(new AnnotationReader));
+        $this->invoker = new Invoker(new NamedParameter(new ArrayCache, new VoidParameterHandler), new OptionsRenderer(new AnnotationReader));
     }
 
     public function testInvoke()
@@ -190,7 +190,7 @@ class InvokerTest extends \PHPUnit_Framework_TestCase
      */
     public function testOptionsNotAllowed()
     {
-        $invoker = new Invoker(new NamedParameter(new ArrayCache, new VoidParamHandler), new VoidOptionsRenderer);
+        $invoker = new Invoker(new NamedParameter(new ArrayCache, new VoidParameterHandler), new VoidOptionsRenderer);
         $request = new Request($this->invoker, new Order, Request::DELETE);
         $invoker->invoke($request);
     }

--- a/tests/LinkerTest.php
+++ b/tests/LinkerTest.php
@@ -35,7 +35,7 @@ class LinkerTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->invoker = new Invoker(new NamedParameter(new ArrayCache, new VoidParamHandler), new OptionsRenderer(new AnnotationReader()));
+        $this->invoker = new Invoker(new NamedParameter(new ArrayCache, new VoidParameterHandler), new OptionsRenderer(new AnnotationReader()));
         $schemeCollection = (new SchemeCollection)
             ->scheme('app')
             ->host('self')

--- a/tests/NamedParameterTest.php
+++ b/tests/NamedParameterTest.php
@@ -19,7 +19,7 @@ class NamedParameterTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->params = new NamedParameter(new ArrayCache, new VoidParamHandler);
+        $this->params = new NamedParameter(new ArrayCache, new VoidParameterHandler);
     }
 
     public function testGetParameters()

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -33,7 +33,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->invoker = new Invoker(new NamedParameter(new ArrayCache, new VoidParamHandler), new OptionsRenderer(new AnnotationReader));
+        $this->invoker = new Invoker(new NamedParameter(new ArrayCache, new VoidParameterHandler), new OptionsRenderer(new AnnotationReader));
         $entry = new Entry;
         $entry->uri = new Uri('test://self/path/to/resource');
         $this->request = new Request($this->invoker, $entry);

--- a/tests/ResourceParamHandlerTest.php
+++ b/tests/ResourceParamHandlerTest.php
@@ -35,7 +35,7 @@ class ResourceParamHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $instance = $this->resource->post->uri('app://self/rparam/greeting')->withQuery(['name' => 'BEAR'])->eager->request();
 
-        $this->assertSame('login:BEAR', $instance['name']);
+        $this->assertSame('login:BEAR', $instance['id']);
     }
 
     public function testException()

--- a/tests/ResourceParamHandlerTest.php
+++ b/tests/ResourceParamHandlerTest.php
@@ -6,7 +6,6 @@
  */
 namespace BEAR\Resource;
 
-use BEAR\Resource\Exception\ParameterException;
 use BEAR\Resource\Module\ResourceModule;
 use Ray\Di\Injector;
 
@@ -38,9 +37,11 @@ class ResourceParamHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('login:BEAR', $instance['id']);
     }
 
+    /**
+     * @expectedException \BEAR\Resource\Exception\ParameterException
+     */
     public function testException()
     {
-        $this->setExpectedException(ParameterException::class, null, Code::BAD_REQUEST);
         $this->resource->put->uri('app://self/rparam/greeting')->eager->request();
     }
 }

--- a/tests/ResourceParamHandlerTest.php
+++ b/tests/ResourceParamHandlerTest.php
@@ -31,6 +31,13 @@ class ResourceParamHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('sunday', $instance['name']);
     }
 
+    public function testResourceParamInUriTemplate()
+    {
+        $instance = $this->resource->post->uri('app://self/rparam/greeting')->withQuery(['name' => 'BEAR'])->eager->request();
+
+        $this->assertSame('login:BEAR', $instance['name']);
+    }
+
     public function testException()
     {
         $this->setExpectedException(ParameterException::class, null, Code::BAD_REQUEST);

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -40,7 +40,7 @@ class ResourceTest extends \PHPUnit_Framework_TestCase
             ->scheme('app')->host('self')->toAdapter(new AppAdapter($injector, 'FakeVendor\Sandbox', 'Resource\App'))
             ->scheme('page')->host('self')->toAdapter(new AppAdapter($injector, 'FakeVendor\Sandbox', 'Resource\Page'))
             ->scheme('nop')->host('self')->toAdapter(new FakeNop);
-        $invoker = new Invoker(new NamedParameter(new ArrayCache, new VoidParamHandler), new OptionsRenderer($reader));
+        $invoker = new Invoker(new NamedParameter(new ArrayCache, new VoidParameterHandler), new OptionsRenderer($reader));
         $factory = new Factory($scheme);
         $resource = new Resource($factory, $invoker, new Anchor($reader), new Linker($reader, $invoker, $factory));
         $this->assertInstanceOf(ResourceInterface::class, $resource);


### PR DESCRIPTION
`@ResourceParam` supports uri template.

The result of resource request `app://self/rparam/login{?name}#nickname` is injected to the`id` parameter. 

```php
    /**
     * @ResourceParam(param="id", uri="app://self/rparam/login{?name}#nickname", templated=true)
     */
    public function onPost($id, $name)
    {
```