### PR TITLE
Ignore assisted parameter in OPTIONS request

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     "require-dev": {
         "phpunit/phpunit": "~5.7 < 6.0",
         "squizlabs/php_codesniffer": "^2.8",
-        "phpmd/phpmd": "^2.6"
+        "phpmd/phpmd": "^2.6",
+        "friendsofphp/php-cs-fixer": "^2.3"
     },
     "suggest": {
         "ext-uri_template": "ext/uri_template for URI Template(RFC6570) specification."

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,7 @@
     "require-dev": {
         "phpunit/phpunit": "~5.7 < 6.0",
         "squizlabs/php_codesniffer": "^2.8",
-        "phpmd/phpmd": "^2.6",
-        "friendsofphp/php-cs-fixer": "^2.3"
+        "phpmd/phpmd": "^2.6"
     },
     "suggest": {
         "ext-uri_template": "ext/uri_template for URI Template(RFC6570) specification."

--- a/src/OptionsRenderer.php
+++ b/src/OptionsRenderer.php
@@ -6,8 +6,10 @@
  */
 namespace BEAR\Resource;
 
+use BEAR\Resource\Annotation\ResourceParam;
 use Doctrine\Common\Annotations\Reader;
 use phpDocumentor\Reflection\DocBlockFactory;
+use Ray\Di\Di\Assisted;
 
 /** @noinspection PhpInconsistentReturnPointsInspection */
 
@@ -106,6 +108,19 @@ final class OptionsRenderer implements RenderInterface
         }
         if ((bool) $required) {
             $paramMetas['required'] = $required;
+        }
+        $annotations = $this->reader->getMethodAnnotations($method);
+        foreach ($annotations as $annotation) {
+            if ($annotation instanceof ResourceParam) {
+                unset($paramMetas['parameters'][$annotation->param]);
+                $paramMetas['required'] = array_values(array_diff($paramMetas['required'], [$annotation->param]));
+            }
+            if ($annotation instanceof Assisted) {
+                $paramMetas['required'] = array_values(array_diff($paramMetas['required'], $annotation->values));
+                foreach ($annotation->values as $varName) {
+                    unset($paramMetas['parameters'][$varName]);
+                }
+            }
         }
 
         return $doc + $paramMetas;

--- a/src/OptionsRenderer.php
+++ b/src/OptionsRenderer.php
@@ -109,19 +109,7 @@ final class OptionsRenderer implements RenderInterface
         if ((bool) $required) {
             $paramMetas['required'] = $required;
         }
-        $annotations = $this->reader->getMethodAnnotations($method);
-        foreach ($annotations as $annotation) {
-            if ($annotation instanceof ResourceParam) {
-                unset($paramMetas['parameters'][$annotation->param]);
-                $paramMetas['required'] = array_values(array_diff($paramMetas['required'], [$annotation->param]));
-            }
-            if ($annotation instanceof Assisted) {
-                $paramMetas['required'] = array_values(array_diff($paramMetas['required'], $annotation->values));
-                foreach ($annotation->values as $varName) {
-                    unset($paramMetas['parameters'][$varName]);
-                }
-            }
-        }
+        $paramMetas = $this->ignoreAssistedPrameter($method, $paramMetas);
 
         return $doc + $paramMetas;
     }
@@ -253,5 +241,27 @@ final class OptionsRenderer implements RenderInterface
         }
 
         return $params;
+    }
+
+    /**
+     * @return array
+     */
+    private function ignoreAssistedPrameter(\ReflectionMethod $method, array $paramMetas)
+    {
+        $annotations = $this->reader->getMethodAnnotations($method);
+        foreach ($annotations as $annotation) {
+            if ($annotation instanceof ResourceParam) {
+                unset($paramMetas['parameters'][$annotation->param]);
+                $paramMetas['required'] = array_values(array_diff($paramMetas['required'], [$annotation->param]));
+            }
+            if ($annotation instanceof Assisted) {
+                $paramMetas['required'] = array_values(array_diff($paramMetas['required'], $annotation->values));
+                foreach ($annotation->values as $varName) {
+                    unset($paramMetas['parameters'][$varName]);
+                }
+            }
+        }
+
+        return $paramMetas;
     }
 }

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/DocPhp7.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/DocPhp7.php
@@ -2,7 +2,9 @@
 
 namespace FakeVendor\Sandbox\Resource\App;
 
+use BEAR\Resource\Annotation\ResourceParam;
 use BEAR\Resource\ResourceObject;
+use Ray\Di\Di\Assisted;
 
 class DocPhp7 extends ResourceObject
 {
@@ -10,12 +12,14 @@ class DocPhp7 extends ResourceObject
      * @param int    $id          Id
      * @param string $name        Name
      * @param bool   $sw          Swithc
+     * @param string $login_id    Login ID
      * @param array  $arr
      * @param string $defaultNull DefaultNull
      *
-     * @return $this
+     * @ResourceParam(param="login_id", uri="app://self/login#id")
+     * @Assisted({"time"})
      */
-    public function onGet(int $id, string $name, bool $sw, array $arr, $defaultNull = null)
+    public function onGet(int $id, string $name, bool $sw, string $login_id, array $arr, string $time, $defaultNull = null)
     {
         return $this;
     }

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/DocPhp7.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/DocPhp7.php
@@ -14,6 +14,7 @@ class DocPhp7 extends ResourceObject
      * @param bool   $sw          Swithc
      * @param string $login_id    Login ID
      * @param array  $arr
+     * @param string $time
      * @param string $defaultNull DefaultNull
      *
      * @ResourceParam(param="login_id", uri="app://self/login#id")


### PR DESCRIPTION
`@ResourceParam` and `@Assisted` are ignored in OPTIONS method.