### PR TITLE
Add AbstracAsssistedParam to prohibit override parameter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.6.0",
         "ray/di": "^2.5",
-        "nocarrier/hal":"^0.9",
+        "nocarrier/hal":"^0.9.12",
         "doctrine/cache":"^1.6",
         "rize/uri-template": "^0.3",
         "phpdocumentor/reflection-docblock": "^3.1",

--- a/src/Annotation/AbstracAsssistedParam.php
+++ b/src/Annotation/AbstracAsssistedParam.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Resource\Annotation;
+
+/**
+ * Assisted parameter abstract class
+ */
+abstract class AbstracAsssistedParam
+{
+    public $param;
+}

--- a/src/AssistedParam.php
+++ b/src/AssistedParam.php
@@ -11,6 +11,10 @@ use Ray\Di\InjectorInterface;
 final class AssistedParam implements ParamInterface
 {
     /**
+     * Return null to prevent override parameter
+     *
+     * This parameter is injected by AOP
+     *
      * {@inheritdoc}
      */
     public function __invoke($varName, array $query, InjectorInterface $injector)

--- a/src/NamedParameter.php
+++ b/src/NamedParameter.php
@@ -6,6 +6,7 @@
  */
 namespace BEAR\Resource;
 
+use BEAR\Resource\Annotation\AbstracAsssistedParam;
 use BEAR\Resource\Annotation\ResourceParam;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Cache\Cache;
@@ -106,6 +107,9 @@ final class NamedParameter implements NamedParameterInterface
             if ($annotation instanceof Assisted) {
                 $names = $this->setAssistedAnnotation($names, $annotation);
             }
+            if ($annotation instanceof AbstracAsssistedParam) {
+                $names = $this->setAssistedParam($names, $annotation);
+            }
         }
 
         return $names;
@@ -124,6 +128,16 @@ final class NamedParameter implements NamedParameterInterface
         foreach ($assisted->values as $assistedParam) {
             $names[$assistedParam] = new AssistedParam;
         }
+
+        return $names;
+    }
+
+    /**
+     * @return array
+     */
+    private function setAssistedParam(array $names, AbstracAsssistedParam $asssistedParam)
+    {
+        $names[$asssistedParam->param] = new AssistedParam;
 
         return $names;
     }


### PR DESCRIPTION
Added `AbstracAsssistedParam` abstract class. This is an annotation abstract class to specify parameter is not override from given parameters with `withQuery`. 