### PR TITLE
Add JsonSchemalModule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "rize/uri-template": "^0.3",
         "phpdocumentor/reflection-docblock": "^3.1",
         "koriym/http-constants": "^1.0",
-        "ray/web-param-module": "^2.0"
+        "ray/web-param-module": "^2.0",
+        "justinrainbow/json-schema": "^5.2"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.7 < 6.0",

--- a/src/Annotation/JsonSchema.php
+++ b/src/Annotation/JsonSchema.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Resource\Annotation;
+
+/**
+ * @Annotation
+ * @Target("METHOD")
+ */
+final class JsonSchema
+{
+    /**
+     * Json schema file name
+     *
+     * @var string
+     */
+    public $value;
+}

--- a/src/Exception/JsonSchemaErrorException.php
+++ b/src/Exception/JsonSchemaErrorException.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Resource\Exception;
+
+class JsonSchemaErrorException extends \LogicException implements ExceptionInterface
+{
+}

--- a/src/Exception/JsonSchemaException.php
+++ b/src/Exception/JsonSchemaException.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Resource\Exception;
+
+class JsonSchemaException extends \LogicException implements ExceptionInterface
+{
+}

--- a/src/Interceptor/JsonSchemaInterceptor.php
+++ b/src/Interceptor/JsonSchemaInterceptor.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Resource\Interceptor;
+
+use BEAR\Resource\Code;
+use BEAR\Resource\Exception\JsonSchemaErrorException;
+use BEAR\Resource\Exception\JsonSchemaException;
+use JsonSchema\Validator;
+use Ray\Aop\MethodInterceptor;
+use Ray\Aop\MethodInvocation;
+use Ray\Aop\WeavedInterface;
+
+final class JsonSchemaInterceptor implements MethodInterceptor
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function invoke(MethodInvocation $invocation)
+    {
+        $result = $invocation->proceed();
+        $object = $invocation->getThis();
+        /* @var $result \BEAR\Resource\ResourceObject */
+        $ref = new \ReflectionClass($object);
+        $thisFile = $object instanceof WeavedInterface ? $thisFile = $ref->getParentClass()->getFileName() : $ref->getFileName();
+        $schemaFile = str_replace('.php', '.json', $thisFile);
+        $validator = new Validator;
+        $data = (object) $result->body;
+        $validator->validate($data, (object) ['$ref' => 'file://' . $schemaFile]);
+        $isValid = $validator->isValid();
+        if ($isValid === true) {
+            return $result;
+        }
+
+        $e = null;
+        foreach ($validator->getErrors() as $error) {
+            $msg = sprintf('[%s] %s', $error['property'], $error['message']);
+            $e = $e ? new JsonSchemaErrorException($msg, 0, $e) : new JsonSchemaErrorException($msg);
+        }
+        throw new JsonSchemaException($schemaFile, Code::ERROR, $e);
+    }
+}

--- a/src/Module/JsonSchemalModule.php
+++ b/src/Module/JsonSchemalModule.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Resource\Module;
+
+use BEAR\Resource\Annotation\JsonSchema;
+use BEAR\Resource\Interceptor\JsonSchemaInterceptor;
+use BEAR\Resource\ResourceObject;
+use Ray\Di\AbstractModule;
+
+class JsonSchemalModule extends AbstractModule
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->bindInterceptor(
+            $this->matcher->subclassesOf(ResourceObject::class),
+            $this->matcher->annotatedWith(JsonSchema::class),
+            [JsonSchemaInterceptor::class]
+        );
+    }
+}

--- a/tests/Fake/JsonSchema/FakePerson.json
+++ b/tests/Fake/JsonSchema/FakePerson.json
@@ -1,0 +1,18 @@
+{
+  "title": "Person",
+  "type": "object",
+  "properties": {
+    "firstName": {
+      "type": "string"
+    },
+    "lastName": {
+      "type": "string"
+    },
+    "age": {
+      "description": "Age in years",
+      "type": "integer",
+      "minimum": 20
+    }
+  },
+  "required": ["firstName", "lastName"]
+}

--- a/tests/Fake/JsonSchema/FakePerson.php
+++ b/tests/Fake/JsonSchema/FakePerson.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Resource\JsonSchema;
+
+use BEAR\Resource\Annotation\JsonSchema;
+use BEAR\Resource\ResourceObject;
+
+class FakePerson extends ResourceObject
+{
+    /**
+     * @JsonSchema
+     */
+    public function onGet()
+    {
+        $this->body = [
+            'firstName' => 'mucha',
+            'lastName' => 'alfons',
+            'age' => 12
+        ];
+
+        return $this;
+    }
+}

--- a/tests/Module/JsonSchemalModuleTest.php
+++ b/tests/Module/JsonSchemalModuleTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Resource\Module;
+
+use BEAR\Resource\Exception\JsonSchemaException;
+use BEAR\Resource\JsonSchema\FakePerson;
+use Ray\Di\Injector;
+
+class JsonSchemalModuleTest extends \PHPUnit_Framework_TestCase
+{
+    public function testValidateException()
+    {
+        $e = $this->createJsonSchemaException();
+        $this->assertInstanceOf(JsonSchemaException::class, $e);
+
+        return $e;
+    }
+
+    /**
+     * @depends testValidateException
+     */
+    public function testValidateErrorException(JsonSchemaException $e)
+    {
+        while ($e = $e->getPrevious()) {
+            $errors[] = $e->getMessage();
+        }
+        $expected = ['[age] Must have a minimum value of 20'];
+        $this->assertSame($expected, $errors);
+    }
+
+    private function createJsonSchemaException()
+    {
+        $person = (new Injector(new JsonSchemalModule))->getInstance(FakePerson::class);
+        /* @var $person FakePerson */
+        try {
+            $person->onGet();
+        } catch (JsonSchemaException $e) {
+            return $e;
+        }
+    }
+}


### PR DESCRIPTION
Bind `@JsonSchema` annotated method the JSON Schema validator (AOP)

[JSON Schema](http://json-schema.org/) is a vocabulary that allows you to annotate and validate JSON documents.

Person.php
```php
class Person extends ResourceObject
{
    /**
     * @JsonSchema
     */
    public function onGet()
    {
        $this->body = [
            'firstName' => 'mucha',
            'lastName' => 'alfons',
            'age' => 12
        ];

        return $this;
    }
}
```

Person.json
```json
{
  "title": "Person",
  "type": "object",
  "properties": {
    "firstName": {
      "type": "string"
    },
    "lastName": {
      "type": "string"
    },
    "age": {
      "description": "Age in years",
      "type": "integer",
      "minimum": 20
    }
  },
  "required": ["firstName", "lastName"]
}
```

Exception thrown when validation faild.

```php
/* @var $e BEAR\Resource\Exception\JsonSchemaException */
 while ($e = $e->getPrevious()) {
     $errors[] = $e->getMessage();
 }
print_r($errors);
// Array
// (
//     [0] => [age] Must have a minimum value of 20
// )
```