### PR TITLE
#109 conflict for phpdocumentor/reflection-docblock 3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "nocarrier/hal":"^0.9.12",
         "doctrine/cache":"^1.6",
         "rize/uri-template": "^0.3",
-        "phpdocumentor/reflection-docblock": "3.1.1",
+        "phpdocumentor/reflection-docblock": "^3.1",
         "koriym/http-constants": "^1.0",
         "ray/web-param-module": "^2.0",
         "justinrainbow/json-schema": "^5.2"
@@ -30,6 +30,9 @@
         "phpunit/phpunit": "~5.7 < 6.0",
         "squizlabs/php_codesniffer": "^2.8",
         "phpmd/phpmd": "^2.6"
+    },
+    "conflict": {
+        "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0"
     },
     "suggest": {
         "ext-uri_template": "ext/uri_template for URI Template(RFC6570) specification."

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "nocarrier/hal":"^0.9.12",
         "doctrine/cache":"^1.6",
         "rize/uri-template": "^0.3",
-        "phpdocumentor/reflection-docblock": "^3.1",
+        "phpdocumentor/reflection-docblock": "3.1.1",
         "koriym/http-constants": "^1.0",
         "ray/web-param-module": "^2.0",
         "justinrainbow/json-schema": "^5.2"


### PR DESCRIPTION
phpdocumentor/reflection-docblock v 3.2.0 cause the error.

1) BEAR\Resource\InvokerTest::testOptionsMethod
InvalidArgumentException: The tag "@Link(rel="friend",
href="/fiend{?id}")" does not seem to be wellformed, please check it
for errors

https://travis-ci.org/bearsunday/BEAR.Resource/jobs/241904934