### PR TITLE
@JsonSchema takes index key

### DIFF
--- a/src/Annotation/JsonSchema.php
+++ b/src/Annotation/JsonSchema.php
@@ -13,9 +13,9 @@ namespace BEAR\Resource\Annotation;
 final class JsonSchema
 {
     /**
-     * Json schema file name
+     * Json schema body key name
      *
      * @var string
      */
-    public $value;
+    public $key;
 }

--- a/src/Interceptor/JsonSchemaInterceptor.php
+++ b/src/Interceptor/JsonSchemaInterceptor.php
@@ -23,23 +23,22 @@ final class JsonSchemaInterceptor implements MethodInterceptor
      */
     public function invoke(MethodInvocation $invocation)
     {
-        $result = $invocation->proceed();
-        $object = $invocation->getThis();
-        /* @var $object ResourceObject */
-        if ($object->code !== 200) {
-            return $result;
+        $ro = $invocation->proceed();
+        /* @var $ro \BEAR\Resource\ResourceObject */
+        if ($ro->code !== 200) {
+            return $ro;
         }
         /* @var $result \BEAR\Resource\ResourceObject */
-        $ref = new \ReflectionClass($object);
-        $thisFile = $object instanceof WeavedInterface ? $thisFile = $ref->getParentClass()->getFileName() : $ref->getFileName();
+        $ref = new \ReflectionClass($ro);
+        $thisFile = $ro instanceof WeavedInterface ? $thisFile = $ref->getParentClass()->getFileName() : $ref->getFileName();
         $schemaFile = str_replace('.php', '.json', $thisFile);
         $validator = new Validator;
         $jsonSchema = $invocation->getMethod()->getAnnotation(JsonSchema::class);
-        $data = $this->getBodyAsObject($jsonSchema, $object);
+        $data = $this->getBodyAsObject($jsonSchema, $ro);
         $validator->validate($data, (object) ['$ref' => 'file://' . $schemaFile]);
         $isValid = $validator->isValid();
         if ($isValid === true) {
-            return $result;
+            return $ro;
         }
 
         $e = null;

--- a/src/Interceptor/JsonSchemaInterceptor.php
+++ b/src/Interceptor/JsonSchemaInterceptor.php
@@ -25,6 +25,10 @@ final class JsonSchemaInterceptor implements MethodInterceptor
     {
         $result = $invocation->proceed();
         $object = $invocation->getThis();
+        /* @var $object ResourceObject */
+        if ($object->code !== 200) {
+            return $result;
+        }
         /* @var $result \BEAR\Resource\ResourceObject */
         $ref = new \ReflectionClass($object);
         $thisFile = $object instanceof WeavedInterface ? $thisFile = $ref->getParentClass()->getFileName() : $ref->getFileName();

--- a/src/Interceptor/JsonSchemaInterceptor.php
+++ b/src/Interceptor/JsonSchemaInterceptor.php
@@ -28,7 +28,6 @@ final class JsonSchemaInterceptor implements MethodInterceptor
         if ($ro->code !== 200) {
             return $ro;
         }
-        /* @var $result \BEAR\Resource\ResourceObject */
         $ref = new \ReflectionClass($ro);
         $thisFile = $ro instanceof WeavedInterface ? $thisFile = $ref->getParentClass()->getFileName() : $ref->getFileName();
         $schemaFile = str_replace('.php', '.json', $thisFile);
@@ -49,6 +48,9 @@ final class JsonSchemaInterceptor implements MethodInterceptor
         throw new JsonSchemaException($schemaFile, Code::ERROR, $e);
     }
 
+    /**
+     * @return object
+     */
     private function getBodyAsObject(JsonSchema $jsonSchema, ResourceObject $ro)
     {
         if ($jsonSchema->value && isset($ro->body[$jsonSchema->value])) {

--- a/src/Interceptor/JsonSchemaInterceptor.php
+++ b/src/Interceptor/JsonSchemaInterceptor.php
@@ -53,8 +53,8 @@ final class JsonSchemaInterceptor implements MethodInterceptor
      */
     private function getBodyAsObject(JsonSchema $jsonSchema, ResourceObject $ro)
     {
-        if ($jsonSchema->value && isset($ro->body[$jsonSchema->value])) {
-            return (object) $ro->body[$jsonSchema->value];
+        if ($jsonSchema->key && isset($ro->body[$jsonSchema->key])) {
+            return (object) $ro->body[$jsonSchema->key];
         }
 
         return (object) $ro->body;


### PR DESCRIPTION
```php
class Todo
{
    public $body = [‘todo => [`name’ =>’foo]];
…
```
When resource body takes "key" for body data, You can specify in annotation as following.

```php
@JsonSchema(key=“todo”)
```

If no key is specified, body has status directory.
```php
@JsonSchema
```

```php
class Todo
{
    public $body = [`name’ =>’foo];
…
```