### PR TITLE
Update @JsonSchema

### DIFF
--- a/src/Annotation/JsonSchema.php
+++ b/src/Annotation/JsonSchema.php
@@ -6,8 +6,6 @@
  */
 namespace BEAR\Resource\Annotation;
 
-use Doctrine\Common\Annotations\Annotation\Enum;
-
 /**
  * @Annotation
  * @Target("METHOD")
@@ -23,7 +21,7 @@ final class JsonSchema
 
     /**
      * Do request valdiation ?
-     * 
+     *
      * @var bool
      */
     public $request = false;

--- a/src/Annotation/JsonSchema.php
+++ b/src/Annotation/JsonSchema.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace BEAR\Resource\Annotation;
 
 /**

--- a/src/Annotation/JsonSchema.php
+++ b/src/Annotation/JsonSchema.php
@@ -22,9 +22,9 @@ final class JsonSchema
     public $key;
 
     /**
-     * Validation target
-     *
-     * @Enum({"none", "request", "response", "request_response"})
+     * Do request valdiation ?
+     * 
+     * @var bool
      */
-    public $validate = 'response';
+    public $request = false;
 }

--- a/src/Annotation/JsonSchema.php
+++ b/src/Annotation/JsonSchema.php
@@ -6,6 +6,8 @@
  */
 namespace BEAR\Resource\Annotation;
 
+use Doctrine\Common\Annotations\Annotation\Enum;
+
 /**
  * @Annotation
  * @Target("METHOD")
@@ -18,4 +20,9 @@ final class JsonSchema
      * @var string
      */
     public $key;
+
+    /**
+     * @Enum({"none", "request", "response", "request_response"})
+     */
+    public $validate = "response";
 }

--- a/src/Annotation/JsonSchema.php
+++ b/src/Annotation/JsonSchema.php
@@ -22,7 +22,9 @@ final class JsonSchema
     public $key;
 
     /**
+     * Validation target
+     *
      * @Enum({"none", "request", "response", "request_response"})
      */
-    public $validate = "response";
+    public $validate = 'response';
 }

--- a/src/Annotation/JsonSchema.php
+++ b/src/Annotation/JsonSchema.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * This file is part of the BEAR.Resource package.
- *
- * @license http://opensource.org/licenses/MIT MIT
- */
 namespace BEAR\Resource\Annotation;
 
 /**
@@ -20,9 +15,14 @@ final class JsonSchema
     public $key;
 
     /**
-     * Do request valdiation ?
-     *
-     * @var bool
+     * @var string
      */
-    public $request = false;
+    public $schema;
+
+    /**
+     * Input parameter validation scheme
+     *
+     * @var string
+     */
+    public $request;
 }

--- a/src/Exception/JsonSchemaDirException.php
+++ b/src/Exception/JsonSchemaDirException.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Resource\Exception;
+
+class JsonSchemaDirException extends \LogicException implements ExceptionInterface
+{
+}

--- a/src/Exception/JsonSchemaNotFoundException.php
+++ b/src/Exception/JsonSchemaNotFoundException.php
@@ -1,0 +1,6 @@
+<?php
+namespace BEAR\Resource\Exception;
+
+class JsonSchemaNotFoundException extends \LogicException implements ExceptionInterface
+{
+}

--- a/src/Exception/JsonSchemaNotFoundException.php
+++ b/src/Exception/JsonSchemaNotFoundException.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace BEAR\Resource\Exception;
 
 class JsonSchemaNotFoundException extends \LogicException implements ExceptionInterface

--- a/src/Interceptor/JsonSchemaInterceptor.php
+++ b/src/Interceptor/JsonSchemaInterceptor.php
@@ -31,9 +31,9 @@ final class JsonSchemaInterceptor implements MethodInterceptor
         $jsonSchema = $invocation->getMethod()->getAnnotation(JsonSchema::class);
         /* @var $jsonSchema JsonSchema */
         $ref = new \ReflectionClass($ro);
-        $thisFile = $ro instanceof WeavedInterface ? $thisFile = $ref->getParentClass()->getFileName() : $ref->getFileName();
+        $roFileName = $ro instanceof WeavedInterface ? $roFileName = $ref->getParentClass()->getFileName() : $ref->getFileName();
         $scanObject = $this->getBodyAsObject($jsonSchema, $ro);
-        $this->validate($scanObject, $jsonSchema, '.php', $thisFile);
+        $this->validate($scanObject, $jsonSchema, '.php', $roFileName);
 
         return $ro;
     }

--- a/src/Interceptor/JsonSchemaInterceptor.php
+++ b/src/Interceptor/JsonSchemaInterceptor.php
@@ -33,23 +33,21 @@ final class JsonSchemaInterceptor implements MethodInterceptor
         $ref = new \ReflectionClass($ro);
         $roFileName = $ro instanceof WeavedInterface ? $roFileName = $ref->getParentClass()->getFileName() : $ref->getFileName();
         if ($jsonSchema->request) {
-            $requestObject = $this->getRequestObject($ro);
             $methodExt = '.' . $ro->uri->method;
-            $this->validate($requestObject, $jsonSchema, $methodExt, $roFileName);
+            $this->validate((object) $ro->uri->query, $methodExt, $roFileName);
         }
         $scanObject = $this->getBodyAsObject($jsonSchema, $ro);
-        $this->validate($scanObject, $jsonSchema, '', $roFileName);
+        $this->validate($scanObject, '', $roFileName);
 
         return $ro;
     }
 
     /**
-     * @param JsonSchema     $jsonSchema
-     * @param ResourceObject $ro
-     * @param string         $ext
-     * @param string         $schemaFile
+     * @param object $scanObject
+     * @param string $methodExt
+     * @param string $thisFile
      */
-    public function validate($scanObject, JsonSchema $jsonSchema, $methodExt, $thisFile)
+    public function validate($scanObject, $methodExt, $thisFile)
     {
         $validator = new Validator;
         $schemaFile = str_replace('.php', "{$methodExt}.json", $thisFile);
@@ -76,15 +74,5 @@ final class JsonSchemaInterceptor implements MethodInterceptor
         }
 
         return (object) $ro->body;
-    }
-
-    /**
-     * @return object
-     */
-    private function getRequestObject(ResourceObject $ro)
-    {
-        $object = (object) $ro->uri->query;
-
-        return $object;
     }
 }

--- a/src/Interceptor/JsonSchemaInterceptor.php
+++ b/src/Interceptor/JsonSchemaInterceptor.php
@@ -1,23 +1,42 @@
 <?php
-/**
- * This file is part of the BEAR.Resource package.
- *
- * @license http://opensource.org/licenses/MIT MIT
- */
 namespace BEAR\Resource\Interceptor;
 
 use BEAR\Resource\Annotation\JsonSchema;
 use BEAR\Resource\Code;
 use BEAR\Resource\Exception\JsonSchemaErrorException;
 use BEAR\Resource\Exception\JsonSchemaException;
+use BEAR\Resource\Exception\JsonSchemaNotFoundException;
 use BEAR\Resource\ResourceObject;
 use JsonSchema\Validator;
 use Ray\Aop\MethodInterceptor;
 use Ray\Aop\MethodInvocation;
 use Ray\Aop\WeavedInterface;
+use Ray\Di\Di\Named;
 
 final class JsonSchemaInterceptor implements MethodInterceptor
 {
+    /**
+     * @var string
+     */
+    private $schemaDir;
+
+    /**
+     * @var string
+     */
+    private $validateDir;
+
+    /**
+     * @param string $schemaDir
+     * @param string $validateDir
+     *
+     * @Named("schemaDir=json_schema_dir,validateDir=json_validate_dir")
+     */
+    public function __construct($schemaDir, $validateDir)
+    {
+        $this->schemaDir = $schemaDir;
+        $this->validateDir = $validateDir;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -30,27 +49,17 @@ final class JsonSchemaInterceptor implements MethodInterceptor
         }
         $jsonSchema = $invocation->getMethod()->getAnnotation(JsonSchema::class);
         /* @var $jsonSchema JsonSchema */
-        $ref = new \ReflectionClass($ro);
-        $roFileName = $ro instanceof WeavedInterface ? $roFileName = $ref->getParentClass()->getFileName() : $ref->getFileName();
         if ($jsonSchema->request) {
-            $methodExt = '.' . $ro->uri->method;
-            $this->validate((object) $ro->uri->query, $methodExt, $roFileName);
+            $this->validateRequest($jsonSchema, $ro);
         }
-        $scanObject = $this->getBodyAsObject($jsonSchema, $ro);
-        $this->validate($scanObject, '', $roFileName);
+        $this->validateResponse($jsonSchema, $ro);
 
         return $ro;
     }
 
-    /**
-     * @param object $scanObject
-     * @param string $methodExt
-     * @param string $thisFile
-     */
-    public function validate($scanObject, $methodExt, $thisFile)
+    public function validate($scanObject, $schemaFile)
     {
         $validator = new Validator;
-        $schemaFile = str_replace('.php', "{$methodExt}.json", $thisFile);
         $validator->validate($scanObject, (object) ['$ref' => 'file://' . $schemaFile]);
         $isValid = $validator->isValid();
         if ($isValid) {
@@ -65,14 +74,47 @@ final class JsonSchemaInterceptor implements MethodInterceptor
     }
 
     /**
-     * @return object
+     * @param $jsonSchema
+     * @param $ro
+     *
+     * @return string
      */
-    private function getBodyAsObject(JsonSchema $jsonSchema, ResourceObject $ro)
+    private function validateRequest($jsonSchema, $ro)
     {
-        if ($jsonSchema->key && isset($ro->body[$jsonSchema->key])) {
-            return (object) $ro->body[$jsonSchema->key];
+        $schemaFile = $this->validateDir . '/' . $jsonSchema->request;
+        if (! file_exists($schemaFile)) {
+            throw new JsonSchemaNotFoundException($schemaFile);
+        }
+        $this->validate((object) $ro->uri->query, $schemaFile);
+    }
+
+    /**
+     * @param $jsonSchema
+     * @param $ro
+     */
+    private function validateResponse($jsonSchema, $ro)
+    {
+        $schemeFile = $this->getSchemaFile($jsonSchema, $ro);
+        $body = isset($ro->body[$jsonSchema->key]) ? (object) $ro->body[$jsonSchema->key] : (object) $ro->body;
+        $this->validate($body, $schemeFile);
+    }
+
+    private function getSchemaFile(JsonSchema $jsonSchema, ResourceObject $ro)
+    {
+        if (! $jsonSchema->schema) {
+            // for BC only
+            $ref = new \ReflectionClass($ro);
+            $roFileName = $ro instanceof WeavedInterface ? $roFileName = $ref->getParentClass()->getFileName() : $ref->getFileName();
+            $bcFile = str_replace('.php', '.json', $roFileName);
+            if (file_exists($bcFile)) {
+                return $bcFile;
+            }
+        }
+        $schemaFile = $this->schemaDir . '/' . $jsonSchema->schema;
+        if (! file_exists($schemaFile) || is_dir($schemaFile)) {
+            throw new JsonSchemaNotFoundException($schemaFile);
         }
 
-        return (object) $ro->body;
+        return $schemaFile;
     }
 }

--- a/src/Interceptor/JsonSchemaInterceptor.php
+++ b/src/Interceptor/JsonSchemaInterceptor.php
@@ -33,7 +33,9 @@ final class JsonSchemaInterceptor implements MethodInterceptor
         $ref = new \ReflectionClass($ro);
         $roFileName = $ro instanceof WeavedInterface ? $roFileName = $ref->getParentClass()->getFileName() : $ref->getFileName();
         $scanObject = $this->getBodyAsObject($jsonSchema, $ro);
-        $this->validate($scanObject, $jsonSchema, '.php', $roFileName);
+        if ($jsonSchema->validate === 'response' | $jsonSchema->validate === 'request') {
+            $this->validate($scanObject, $jsonSchema, '.php', $roFileName);
+        }
 
         return $ro;
     }

--- a/src/Interceptor/JsonSchemaInterceptor.php
+++ b/src/Interceptor/JsonSchemaInterceptor.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace BEAR\Resource\Interceptor;
 
 use BEAR\Resource\Annotation\JsonSchema;
@@ -82,9 +87,7 @@ final class JsonSchemaInterceptor implements MethodInterceptor
     private function validateRequest($jsonSchema, $ro)
     {
         $schemaFile = $this->validateDir . '/' . $jsonSchema->request;
-        if (! file_exists($schemaFile)) {
-            throw new JsonSchemaNotFoundException($schemaFile);
-        }
+        $this->validateFileExists($schemaFile);
         $this->validate((object) $ro->uri->query, $schemaFile);
     }
 
@@ -111,10 +114,18 @@ final class JsonSchemaInterceptor implements MethodInterceptor
             }
         }
         $schemaFile = $this->schemaDir . '/' . $jsonSchema->schema;
+        $this->validateFileExists($schemaFile);
+
+        return $schemaFile;
+    }
+
+    /**
+     * @param $schemaFile
+     */
+    private function validateFileExists($schemaFile)
+    {
         if (! file_exists($schemaFile) || is_dir($schemaFile)) {
             throw new JsonSchemaNotFoundException($schemaFile);
         }
-
-        return $schemaFile;
     }
 }

--- a/src/Module/JsonSchemalModule.php
+++ b/src/Module/JsonSchemalModule.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace BEAR\Resource\Module;
 
 use BEAR\Resource\Annotation\JsonSchema;

--- a/src/Module/JsonSchemalModule.php
+++ b/src/Module/JsonSchemalModule.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * This file is part of the BEAR.Resource package.
- *
- * @license http://opensource.org/licenses/MIT MIT
- */
 namespace BEAR\Resource\Module;
 
 use BEAR\Resource\Annotation\JsonSchema;
@@ -14,10 +9,33 @@ use Ray\Di\AbstractModule;
 class JsonSchemalModule extends AbstractModule
 {
     /**
+     * Json-schema json file directory
+     *
+     * @var string
+     */
+    private $jsonSchemaDir;
+
+    /**
+     * Json-schema validator json file directory
+     *
+     * @var string
+     */
+    private $jsonValidateDir;
+
+    public function __construct($jsonSchemaDir = '', $jsonValidateDir = '', AbstractModule $module = null)
+    {
+        $this->jsonSchemaDir = $jsonSchemaDir;
+        $this->jsonValidateDir = $jsonValidateDir;
+        parent::__construct($module);
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function configure()
     {
+        $this->bind()->annotatedWith('json_schema_dir')->toInstance($this->jsonSchemaDir);
+        $this->bind()->annotatedWith('json_validate_dir')->toInstance($this->jsonValidateDir);
         $this->bindInterceptor(
             $this->matcher->subclassesOf(ResourceObject::class),
             $this->matcher->annotatedWith(JsonSchema::class),

--- a/tests/Fake/JsonSchema/FakeUser.php
+++ b/tests/Fake/JsonSchema/FakeUser.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Resource\JsonSchema;
+
+use BEAR\Resource\Annotation\JsonSchema;
+use BEAR\Resource\ResourceObject;
+
+class FakeUser extends ResourceObject
+{
+    /**
+     * @JsonSchema(schema="user.json", request="user.get.json")
+     */
+    public function onGet($id)
+    {
+        $this->body = [
+            'firstName' => 'mucha',
+            'lastName' => 'alfons',
+            'age' => 12
+        ];
+
+        return $this;
+    }
+
+    /**
+     * @JsonSchema(schema="__invalid.json")
+     */
+    public function onPost()
+    {
+        return $this;
+    }
+}

--- a/tests/Fake/JsonSchema/FakeUser.php
+++ b/tests/Fake/JsonSchema/FakeUser.php
@@ -7,6 +7,7 @@
 namespace BEAR\Resource\JsonSchema;
 
 use BEAR\Resource\Annotation\JsonSchema;
+use BEAR\Resource\Code;
 use BEAR\Resource\ResourceObject;
 
 class FakeUser extends ResourceObject
@@ -14,12 +15,12 @@ class FakeUser extends ResourceObject
     /**
      * @JsonSchema(schema="user.json", request="user.get.json")
      */
-    public function onGet($id)
+    public function onGet($age)
     {
         $this->body = [
             'firstName' => 'mucha',
             'lastName' => 'alfons',
-            'age' => 12
+            'age' => $age
         ];
 
         return $this;
@@ -29,6 +30,25 @@ class FakeUser extends ResourceObject
      * @JsonSchema(schema="__invalid.json")
      */
     public function onPost()
+    {
+        return $this;
+    }
+
+    /**
+     * @JsonSchema(schema="user.json")
+     */
+    public function onPut()
+    {
+        $this->code = Code::NO_CONTENT;
+        $this->body = [];
+
+        return $this;
+    }
+
+    /**
+     * @JsonSchema(request="__invalid.json")
+     */
+    public function onPatch()
     {
         return $this;
     }

--- a/tests/Fake/json_schema/user.json
+++ b/tests/Fake/json_schema/user.json
@@ -1,0 +1,18 @@
+{
+  "title": "Person",
+  "type": "object",
+  "properties": {
+    "firstName": {
+      "type": "string"
+    },
+    "lastName": {
+      "type": "string"
+    },
+    "age": {
+      "description": "Age in years",
+      "type": "integer",
+      "minimum": 20
+    }
+  },
+  "required": ["firstName", "lastName"]
+}

--- a/tests/Fake/json_validate/user.get.json
+++ b/tests/Fake/json_validate/user.get.json
@@ -1,0 +1,9 @@
+{
+  "title": "User",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    }
+  }
+}

--- a/tests/Fake/json_validate/user.get.json
+++ b/tests/Fake/json_validate/user.get.json
@@ -2,8 +2,8 @@
   "title": "User",
   "type": "object",
   "properties": {
-    "id": {
-      "type": "string"
+    "age": {
+      "type": "number"
     }
   }
 }

--- a/tests/VoidOptionsRendererTest.php
+++ b/tests/VoidOptionsRendererTest.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Resource;
+
+use BEAR\Resource\Module\ResourceModule;
+use BEAR\Resource\Module\VoidOptionsMethodModule;
+use Ray\Di\Injector;
+
+class VoidOptionsRendererTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \BEAR\Resource\Exception\MethodNotAllowedException
+     */
+    public function testVoidOptionsRenderer()
+    {
+        $injector = new Injector(new VoidOptionsMethodModule(new FakeSchemeModule(new ResourceModule('FakeVendor\Sandbox')), $_ENV['TMP_DIR']));
+        $resource = $injector->getInstance(ResourceInterface::class);
+        /* @var $resource \BEAR\Resource\ResourceInterface */
+        $resource->options->uri('page://self/index')->eager->request();
+    }
+}


### PR DESCRIPTION
 * scheme json file location by CoC is deprecated.
 * specify `json_schema` and `json_validate` folder in `JsonSchemalModule`
 * @JsonSchema::$schema prop to locate schema file
 * @JsonSchema::$params to locate request validation schema json file
 * @JsonSchema::$key for body array key

Install module

```php
$this->install(new JsonSchemalModule($appDir . '/var/json_schema', $appDir . '/var/json_validate'));
```

Put scheme files under specified directories.

**/var/json_schema/todo.json**
```json
{
  "$schema": "http://json-schema.org/draft-04/schema#",
  "title": "Todo schema",
  "description": "Todo schema that should be used to model todo application.",
  "type": "object",
  "properties": {
    "title": {
      "type": "string",
      "minLength": 1,
      "maxLength": 40
    },
    "status": {
      "enum": ["1", "2"]
    },
    "created": {
      "type": "string",
      "format": "datetime"
    },
    "updated": {
      "type": "string",
      "format": "datetime"
    }
  },
  "required": ["title", "status", "created", "updated"],
  "additionalProperties": true
}

```

**/var/json_validate/todo.post.json**
```json
{
  "$schema": "http://json-schema.org/draft-04/schema#",
  "title": "/todo POST request validation",
  "properties": {
    "title": {
      "type": "string",
      "minLength": 1,
      "maxLength": 40
    }
}
```

Annotate `@JsonScheme` for `input parameters` or (and) `response` validation.

response validation
```php
    /**
     * @JsonSchema(key="todo", schema="todo.json")
     */
    public function onGet(string $id) : ResourceObject
```

request validation
```php
    /**
     * @JsonSchema(params="todo.post.json")
     */
    public function onPost(string $title) : ResourceObject

```

`key` is optional when `body` contains certain `key`. ($this->body[$key] = [...];)
Properties (`key`, `schema` and `request`) can be combined in one @JsonSchema annotation.

Older API still valid with new PR. Backward compatible.

 * plus 100% test coverage
 * include #113 