### PR TITLE
Support single row list with crawl.

### DIFF
--- a/src/Linker.php
+++ b/src/Linker.php
@@ -221,10 +221,12 @@ final class Linker implements LinkerInterface
     private function isList($value)
     {
         $list = $value;
-        $keys = array_keys((array) array_pop($list));
-        $isMultiColumnList = $keys !== [0 => 0] && ($keys === array_keys((array) array_pop($list)));
+        $firstRow = array_pop($list);
+        $keys = array_keys((array) $firstRow);
+        $isMultiColumnMultiRowList = $keys !== [0 => 0] && ($keys === array_keys((array) array_pop($list)));
+        $isMultiColumnList = is_array($firstRow) && array_filter(array_keys($value), 'is_numeric') === array_keys($value);
         $isSingleColumnList = (count($value) === 1) && $keys === array_keys((array) $list);
 
-        return $isSingleColumnList || $isMultiColumnList;
+        return $isSingleColumnList || $isMultiColumnMultiRowList || $isMultiColumnList;
     }
 }

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/Blog.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/Blog.php
@@ -9,7 +9,7 @@ class Blog extends ResourceObject
     private $repo = [
         11 => ['id' => 11, 'name' => 'Athos blog'],
         12 => ['id' => 12, 'name' => 'Aramis blog'],
-        16 => ['id' => 16, 'name' => 'John blog'],
+        16 => ['id' => 16, 'name' => 'Porthos blog'],
         99 => ['id' => 19, 'name' => 'BEAR blog'],
     ];
 

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/Blog.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/Blog.php
@@ -9,6 +9,7 @@ class Blog extends ResourceObject
     private $repo = [
         11 => ['id' => 11, 'name' => 'Athos blog'],
         12 => ['id' => 12, 'name' => 'Aramis blog'],
+        16 => ['id' => 16, 'name' => 'John blog'],
         99 => ['id' => 19, 'name' => 'BEAR blog'],
     ];
 

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/Marshal/Meta.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/Marshal/Meta.php
@@ -33,6 +33,21 @@ class Meta extends ResourceObject
             'post_id' => '5',
             'data' => 'meta 5',
         ],
+        [
+            'id' => '6',
+            'post_id' => '6',
+            'data' => 'meta 6',
+        ],
+        [
+            'id' => '7',
+            'post_id' => '7',
+            'data' => 'meta 7',
+        ],
+        [
+            'id' => '8',
+            'post_id' => '8',
+            'data' => 'meta 8',
+        ],
     ];
 
     /**

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/Marshal/Post.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/Marshal/Post.php
@@ -32,6 +32,23 @@ class Post extends ResourceObject
             'author_id' => '2',
             'body' => 'Clara post #2',
         ],
+        'blog16' => [
+            [
+                'id' => '6',
+                'author_id' => '3',
+                'body' => 'John post #1',
+            ],
+            [
+                'id' => '7',
+                'author_id' => '3',
+                'body' => 'John post #1',
+            ],
+            [
+                'id' => '8',
+                'author_id' => '3',
+                'body' => 'John post #1',
+            ]
+        ]
     ];
 
     /**

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/Marshal/Post.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/Marshal/Post.php
@@ -36,17 +36,17 @@ class Post extends ResourceObject
             [
                 'id' => '6',
                 'author_id' => '3',
-                'body' => 'John post #1',
+                'body' => 'Porthos post #1',
             ],
             [
                 'id' => '7',
                 'author_id' => '3',
-                'body' => 'John post #1',
+                'body' => 'Porthos post #1',
             ],
             [
                 'id' => '8',
                 'author_id' => '3',
-                'body' => 'John post #1',
+                'body' => 'Porthos post #1',
             ]
         ]
     ];

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/Marshal/Tag.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/Marshal/Tag.php
@@ -59,6 +59,21 @@ class Tag extends ResourceObject
             'post_id' => '5',
             'tag_id'  => '2',
         ],
+        [
+            'id' => '11',
+            'post_id' => '6',
+            'tag_id'  => '1',
+        ],
+        [
+            'id' => '12',
+            'post_id' => '7',
+            'tag_id'  => '2',
+        ],
+        [
+            'id' => '13',
+            'post_id' => '8',
+            'tag_id'  => '3',
+        ],
     ];
 
     /**

--- a/tests/LinkerTest.php
+++ b/tests/LinkerTest.php
@@ -158,12 +158,12 @@ class LinkerTest extends TestCase
         $result = $this->linker->invoke($request);
         $expected = [
             'id' => 16,
-            'name' => 'John blog',
+            'name' => 'Porthos blog',
             'post' => [
                 [
                     'id' => '6',
                     'author_id' => '3',
-                    'body' => 'John post #1',
+                    'body' => 'Porthos post #1',
                     'meta' => [
                         [
                             'id' => '6',
@@ -191,7 +191,7 @@ class LinkerTest extends TestCase
                 [
                     'id' => '7',
                     'author_id' => '3',
-                    'body' => 'John post #1',
+                    'body' => 'Porthos post #1',
                     'meta' => [
                         [
                             'id' => '7',
@@ -219,7 +219,7 @@ class LinkerTest extends TestCase
                 [
                     'id' => '8',
                     'author_id' => '3',
-                    'body' => 'John post #1',
+                    'body' => 'Porthos post #1',
                     'meta' => [
                         [
                             'id' => '8',

--- a/tests/LinkerTest.php
+++ b/tests/LinkerTest.php
@@ -146,6 +146,109 @@ class LinkerTest extends TestCase
         $this->assertSame($expected, $result->body);
     }
 
+    public function testAnnotationCrawl2()
+    {
+        $request = new Request(
+            $this->invoker,
+            new Blog,
+            Request::GET,
+            ['id' => 16],
+            [new LinkType('tree', LinkType::CRAWL_LINK)]
+        );
+        $result = $this->linker->invoke($request);
+        $expected = [
+            'id' => 16,
+            'name' => 'John blog',
+            'post' => [
+                [
+                    'id' => '6',
+                    'author_id' => '3',
+                    'body' => 'John post #1',
+                    'meta' => [
+                        [
+                            'id' => '6',
+                            'post_id' => '6',
+                            'data' => 'meta 6',
+                        ],
+                    ],
+                    'tag' => [
+                        [
+                            'id' => '11',
+                            'post_id' => '6',
+                            'tag_id' => '1',
+                            'tag_name' => [
+                                [
+                                    'id' => '1',
+                                    'name' => 'zim',
+                                ],
+                            ],
+                            'tag_type' => [
+                                'type1',
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'id' => '7',
+                    'author_id' => '3',
+                    'body' => 'John post #1',
+                    'meta' => [
+                        [
+                            'id' => '7',
+                            'post_id' => '7',
+                            'data' => 'meta 7',
+                        ],
+                    ],
+                    'tag' => [
+                        [
+                            'id' => '12',
+                            'post_id' => '7',
+                            'tag_id' => '2',
+                            'tag_name' => [
+                                [
+                                    'id' => '2',
+                                    'name' => 'dib',
+                                ],
+                            ],
+                            'tag_type' => [
+                                'type1',
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'id' => '8',
+                    'author_id' => '3',
+                    'body' => 'John post #1',
+                    'meta' => [
+                        [
+                            'id' => '8',
+                            'post_id' => '8',
+                            'data' => 'meta 8',
+                        ],
+                    ],
+                    'tag' => [
+                        [
+                            'id' => '13',
+                            'post_id' => '8',
+                            'tag_id' => '3',
+                            'tag_name' => [
+                                [
+                                        'id' => '3',
+                                        'name' => 'gir',
+                                ],
+                            ],
+                            'tag_type' => [
+                                'type1',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $this->assertSame($expected, $result->body);
+    }
+
     public function testScalarValueLinkThrowException()
     {
         $this->setExpectedException(LinkQueryException::class);


### PR DESCRIPTION
`BEAR\Resource\Linker::isList()` の `$isMultiColumnList` はリストに複数行が内包されていなければ `true` にならず、従って1行だけのリストはリストとして評価されていませんでした。
`$isMultiColumnList` は `$isMultiColumnMultiRowList` に変え、`$value` が配列を内包する数値配列であった場合に `true` となる `$isMultiColumnList` を実装しました。

`$isMultiColumnList` of `BEAR\Resource\Linker::isList()` doens't become `true` unless the list contains more than one line, so the list with only one line wasn't evaluated as a list.
`$isMultiColumnList` has been changed to `$isMultiColumnMultiRowList` and `$isMultiColumnList` is set to `true` if `$value` is an array containing an array.

BTW, I'm not sure whether need be left `$isMultiColumnList` as `$isMultiColumnMultiRowList` so I left it as `$isMultiColumnMultiRowList`.

## Previous Behavior

- Could't be `true`

```
$value = [
	[
		'id' => 1,
		'name' => 'hoge'
	]
];
```

- Could be `true`

```
$value = [
	[
		'id' => 1,
		'name' => 'hoge'
	],
	[
		'id' => 2,
		'name' => 'fuga'
	]
];
```

## Behavior by this commit

- Could be `true`

```
$value = [
	[
		'id' => 1,
		'name' => 'hoge'
	]
];
```

```
$value = [
	[
		'id' => 1,
		'name' => 'hoge'
	],
	[
		'id' => 2,
		'name' => 'fuga'
	]
];
```