### PR TITLE
Enable code, headers and body property in resource request object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build
 cache.properties
 composer.lock
 composer.phar
+.DS_Store
+.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -128,5 +128,4 @@ return \PhpCsFixer\Config::create()
             ->exclude('src-data')
             ->exclude('src-deprecated')
             ->in(__DIR__)
-    )->setLineEnding("\n")
-    ->setUsingCache(false);
+    )->setLineEnding("\n");

--- a/src/AbstractRequest.php
+++ b/src/AbstractRequest.php
@@ -9,6 +9,12 @@ namespace BEAR\Resource;
 use BEAR\Resource\Exception\MethodException;
 use BEAR\Resource\Exception\OutOfBoundsException;
 
+/**
+ * @property string code
+ * @property array headers
+ * @property mixed body
+ * @property string view
+ */
 abstract class AbstractRequest implements RequestInterface, \ArrayAccess, \IteratorAggregate, \Serializable
 {
     const GET = 'get';
@@ -140,6 +146,27 @@ abstract class AbstractRequest implements RequestInterface, \ArrayAccess, \Itera
         }
 
         return $this->invoker->invoke($this);
+    }
+
+    public function __get($name)
+    {
+        if ($name === 'code') {
+            $this->result = $this->invoke();
+
+            return $this->result->code;
+        }
+        if ($name === 'headers') {
+            $this->result = $this->invoke();
+
+            return $this->result->headers;
+        }
+        if ($name === 'body') {
+            $this->result = $this->invoke();
+
+            return $this->result->body;
+        }
+
+        throw new \OutOfRangeException($name);
     }
 
     /**

--- a/src/AbstractRequest.php
+++ b/src/AbstractRequest.php
@@ -150,23 +150,9 @@ abstract class AbstractRequest implements RequestInterface, \ArrayAccess, \Itera
 
     public function __get($name)
     {
-        if ($name === 'code') {
-            $this->result = $this->invoke();
+        $this->result = $this->invoke();
 
-            return $this->result->code;
-        }
-        if ($name === 'headers') {
-            $this->result = $this->invoke();
-
-            return $this->result->headers;
-        }
-        if ($name === 'body') {
-            $this->result = $this->invoke();
-
-            return $this->result->body;
-        }
-
-        throw new \OutOfRangeException($name);
+        return $this->result->$name;
     }
 
     /**

--- a/src/Request.php
+++ b/src/Request.php
@@ -27,9 +27,13 @@ final class Request extends AbstractRequest
      */
     public function __get($name)
     {
-        $this->in = $name;
+        if ($name === 'eager' || $name === 'lazy') {
+            $this->in = $name;
 
-        return $this;
+            return $this;
+        }
+
+        return parent::__get($name);
     }
 
     /**

--- a/src/Request.php
+++ b/src/Request.php
@@ -32,8 +32,11 @@ final class Request extends AbstractRequest
 
             return $this;
         }
+        if ($name === 'code' || $name === 'headers' || $name === 'body') {
+            return parent::__get($name);
+        }
 
-        return parent::__get($name);
+        throw new \OutOfRangeException($name);
     }
 
     /**

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -244,4 +244,47 @@ class RequestTest extends TestCase
         $ro = unserialize(serialize($this->request));
         $this->assertInstanceOf(AbstractRequest::class, $ro);
     }
+
+    public function testCode()
+    {
+        $request = new Request(
+            $this->invoker,
+            $this->fake,
+            Request::GET,
+            ['a' => 'koriym', 'b' => 25]
+        );
+        $newRequest = clone $request;
+        $code = $newRequest->code;
+        $this->assertSame(200, $code);
+
+        return $request;
+    }
+
+    /**
+     * @depends testCode
+     */
+    public function testHeaders(Request $request)
+    {
+        $headers = $request->headers;
+        $this->assertSame([], $headers);
+    }
+
+    /**
+     * @depends testCode
+     */
+    public function testBody(Request $request)
+    {
+        $body = $request->body;
+        $expected = ['posts' => ['koriym', 25]];
+        $this->assertSame($expected, $body);
+    }
+
+    /**
+     * @depends testCode
+     */
+    public function testInvalidProp(Request $request)
+    {
+        $this->expectException(\OutOfRangeException::class);
+        $request->__invalid__;
+    }
 }

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -138,7 +138,9 @@ class ResourceTest extends TestCase
                 'age' => 16,
                 'blog_id' => 12,
                 'blog' => ['id' => 12, 'name' => 'Aramis blog']
-            ], $ro->body);
+            ],
+            $ro->body
+        );
     }
 
     public function testLinkCrawl()


### PR DESCRIPTION
Like array access with request object, public property access with code, headers, or body invoke eager resource request then return the property.

before
```php
$request = $resource->uri('app://self/user');
$request->code // error
```
after 

```php
$request = $resource->uri('app://self/user');
$request->code // invoke request then return code;
```