### PR TITLE
E_USER_WARNING when exception caught in ResourceObject::__toString()

### DIFF
--- a/src/ResourceObject.php
+++ b/src/ResourceObject.php
@@ -70,7 +70,8 @@ abstract class ResourceObject implements AcceptTransferInterface, ArrayAccess, C
         try {
             $view = $this->toString();
         } catch (Exception $e) {
-            trigger_error($e->getMessage() . PHP_EOL . $e->getTraceAsString(), E_USER_ERROR);
+            $msg = sprintf("%s(%s)\n%s", get_class($e), $e->getMessage(), $e->getTraceAsString());
+            trigger_error($msg, E_USER_WARNING);
 
             return '';
         }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -161,7 +161,7 @@ class RequestTest extends TestCase
             $str = $errstr;
         });
         (string) $request;
-        $this->assertSame(256, $no);
+        $this->assertSame(E_USER_WARNING, $no);
         $this->assertContains('FakeErrorRenderer->render', $str);
         $this->assertSame('', (string) $request);
         restore_error_handler();


### PR DESCRIPTION
was E_USER_ERROR