### PR TITLE
fix Linker->isList

### DIFF
--- a/src/Linker.php
+++ b/src/Linker.php
@@ -211,9 +211,19 @@ final class Linker implements LinkerInterface
         return $isSingleColumnList || $isMultiColumnMultiRowList || $isMultiColumnList;
     }
 
-    private function isMultiColumnMultiRowList(array $keys, $list) : bool
+    private function isMultiColumnMultiRowList(array $keys, array $list) : bool
     {
-        return $keys !== [0 => 0] && ($keys === array_keys((array) array_pop($list)));
+        if ($keys === [0 => 0]) {
+            return false;
+        }
+
+        foreach ($list as $item) {
+            if ($keys !== array_keys((array) $item)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private function isMultiColumnList(array $value, $firstRow) : bool

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/Blog.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/Blog.php
@@ -17,6 +17,18 @@ class Blog extends ResourceObject
         11 => ['id' => 11, 'name' => 'Athos blog'],
         12 => ['id' => 12, 'name' => 'Aramis blog'],
         16 => ['id' => 16, 'name' => 'Porthos blog'],
+        17 => [
+            'id' => 17,
+            'name' => 'My blog',
+            'label' => [
+                'a',
+                'b'
+            ],
+            'keyword' => [
+                'c',
+                'd'
+            ],
+        ],
         99 => ['id' => 19, 'name' => 'BEAR blog'],
     ];
 

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/Marshal/Post.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/Marshal/Post.php
@@ -55,7 +55,12 @@ class Post extends ResourceObject
                 'author_id' => '3',
                 'body' => 'Porthos post #1',
             ]
-        ]
+        ],
+        'blog17' => [
+            'id' => '9',
+            'author_id' => '4',
+            'body' => 'My post #1',
+        ],
     ];
 
     /**

--- a/tests/LinkerTest.php
+++ b/tests/LinkerTest.php
@@ -251,6 +251,38 @@ class LinkerTest extends TestCase
         $this->assertSame($expected, $result->body);
     }
 
+    public function testAnnotationCrawl3()
+    {
+        $request = new Request(
+            $this->invoker,
+            new Blog,
+            Request::GET,
+            ['id' => 17],
+            [new LinkType('tree', LinkType::CRAWL_LINK)]
+        );
+        $result = $this->linker->invoke($request);
+        $expected = [
+            'id' => 17,
+            'name' => 'My blog',
+            'label' => [
+                'a',
+                'b'
+            ],
+            'keyword' => [
+                'c',
+                'd'
+            ],
+            'post' => [
+                'id' => '9',
+                'author_id' => '4',
+                'body' => 'My post #1',
+                'meta' => [],
+                'tag' => [],
+            ],
+        ];
+        $this->assertSame($expected, $result->body);
+    }
+
     public function testScalarValueLinkThrowException()
     {
         $this->expectException(LinkQueryException::class);


### PR DESCRIPTION
```php
    /**
     * @Link(rel="post", href="app://self/marshal/post?blog_id={id}", crawl="tree")
     */
    public function onGet($id)
    {
        $this->body = [
            'id' => 17,
            'name' => 'My blog',
            'label' => [
                'a',
                'b'
            ],
            'keyword' => [
                'c',
                'd'
            ],
        ];
    }
```

このデータの様に、リソース内 body の最後二つのプロパティ(上記では label と keyword) が array で、かつ同じキーを持っているリソースから、linkCrawl を行おうとした場合に、
Linker->isList() で `true` が返ってしまい、エラーが発生してしまいます。

```
> phpunit
PHPUnit 6.5.9 by Sebastian Bergmann and contributors.

...................................................E...........  63 / 170 ( 37%)
............................................................... 126 / 170 ( 74%)
............................................                    170 / 170 (100%)

Time: 2.56 seconds, Memory: 64.00MB

There was 1 error:

1) BEAR\Resource\LinkerTest::testAnnotationCrawl3
TypeError: Argument 3 passed to BEAR\Resource\Linker::crawl() must be of the type array, integer given, called in /Users/iwasaki/Downloads/BEAR.Resource/src/Linker.php on line 164

/Users/iwasaki/Downloads/BEAR.Resource/src/Linker.php:178
/Users/iwasaki/Downloads/BEAR.Resource/src/Linker.php:164
/Users/iwasaki/Downloads/BEAR.Resource/src/Linker.php:116
/Users/iwasaki/Downloads/BEAR.Resource/src/Linker.php:65
/Users/iwasaki/Downloads/BEAR.Resource/tests/LinkerTest.php:263

ERRORS!
Tests: 170, Assertions: 228, Errors: 1.
```

詳細はこのプルリクに含まれるテストコードも参照ください。

こちらを解決するためのプルリクを送ります。
よろしくお願いします。