### PR TITLE
Add eager request method

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -11,8 +11,8 @@ namespace BEAR\Resource;
 /**
  * @property $this $get
  * @property $this $post
- * @property $this $patch
  * @property $this $put
+ * @property $this $patch
  * @property $this $delete
  * @property $this $head
  * @property $this $options
@@ -134,5 +134,54 @@ final class Resource implements ResourceInterface
         list($method, $uri) = $this->anchor->href($rel, $this->request, $query);
 
         return $this->{$method}->uri($uri)->addQuery($query)->eager->request();
+    }
+
+    public function get(string $uri, array $query) : ResourceObject
+    {
+        $this->method = Request::GET;
+
+        return $this->uri(new Uri($uri))($query);
+    }
+
+    public function post(string $uri, array $query) : ResourceObject
+    {
+        $this->method = Request::POST;
+
+        return $this->uri(new Uri($uri))($query);
+    }
+
+    public function put(string $uri, array $query) : ResourceObject
+    {
+        $this->method = Request::PUT;
+
+        return $this->uri(new Uri($uri))($query);
+    }
+
+    public function patch(string $uri, array $query) : ResourceObject
+    {
+        $this->method = Request::PATCH;
+
+        return $this->uri(new Uri($uri))($query);
+    }
+
+    public function delete(string $uri, array $query) : ResourceObject
+    {
+        $this->method = Request::DELETE;
+
+        return $this->uri(new Uri($uri))($query);
+    }
+
+    public function options(string $uri, array $query) : ResourceObject
+    {
+        $this->method = Request::OPTIONS;
+
+        return $this->uri(new Uri($uri))($query);
+    }
+
+    public function head(string $uri, array $query) : ResourceObject
+    {
+        $this->method = Request::HEAD;
+
+        return $this->uri(new Uri($uri))($query);
     }
 }

--- a/src/ResourceInterface.php
+++ b/src/ResourceInterface.php
@@ -11,8 +11,8 @@ namespace BEAR\Resource;
 /**
  * @property $this $get
  * @property $this $post
- * @property $this $patch
  * @property $this $put
+ * @property $this $patch
  * @property $this $delete
  * @property $this $head
  * @property $this $options
@@ -42,4 +42,34 @@ interface ResourceInterface
      * Hyper reference (Hypertext As The Engine Of Application State)
      */
     public function href(string $rel, array $query = []) : ResourceObject;
+
+    /**
+     * Invoke GET request
+     */
+    public function get(string $uri, array $query) : ResourceObject;
+
+    /**
+     * Invoke POST request
+     */
+    public function post(string $uri, array $query) : ResourceObject;
+
+    /**
+     * Invoke PUT request
+     */
+    public function put(string $uri, array $query) : ResourceObject;
+
+    /**
+     * Invoke PATCH request
+     */
+    public function patch(string $uri, array $query) : ResourceObject;
+
+    /**
+     * Invoke DELETE request
+     */
+    public function delete(string $uri, array $query) : ResourceObject;
+
+    /**
+     * Invoke HEAD request
+     */
+    public function head(string $uri, array $query) : ResourceObject;
 }

--- a/tests/Fake/FakeVendor/Sandbox/Resource/Page/Index.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/Page/Index.php
@@ -16,4 +16,24 @@ class Index extends ResourceObject
     {
         return $id;
     }
+
+    public function onPost(string $name)
+    {
+        return 'post ' . $name;
+    }
+
+    public function onPut(string $name)
+    {
+        return 'put ' . $name;
+    }
+
+    public function onPatch(string $name)
+    {
+        return 'patch ' . $name;
+    }
+
+    public function onDelete(string $name)
+    {
+        return 'delete ' . $name;
+    }
 }

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -18,8 +18,8 @@ use FakeVendor\Sandbox\Resource\App\Href\Origin;
 use FakeVendor\Sandbox\Resource\App\Href\Target;
 use FakeVendor\Sandbox\Resource\Page\Index;
 use PHPUnit\Framework\TestCase;
-use Ray\Di\EmptyModule;
 use Ray\Di\Injector;
+use Ray\Di\NullModule;
 
 class ResourceTest extends TestCase
 {
@@ -37,7 +37,7 @@ class ResourceTest extends TestCase
 
     public function testManualConstruction()
     {
-        $injector = new Injector(new EmptyModule, $_ENV['TMP_DIR']);
+        $injector = new Injector(new NullModule, $_ENV['TMP_DIR']);
         $reader = new AnnotationReader;
         $scheme = (new SchemeCollection)
             ->scheme('app')->host('self')->toAdapter(new AppAdapter($injector, 'FakeVendor\Sandbox'))
@@ -200,6 +200,8 @@ class ResourceTest extends TestCase
             ],
         ];
         $this->assertSame($expected, $ro->body);
+
+        return $expected;
     }
 
     public function testHal()
@@ -250,5 +252,35 @@ class ResourceTest extends TestCase
         $ro = $resource->get->uri('page://self/assist')->withQuery(['login_id' => '_WILL_BE_IGNORED_'])->eager->request();
         /* @var $ro \BEAR\Resource\ResourceObject */
         $this->assertSame('login_id:assisted01', $ro->body);
+    }
+
+    public function testGet()
+    {
+        $ro = $this->resource->get('page://self/index', ['id' => 1]);
+        $this->assertSame(1, $ro->body);
+    }
+
+    public function testPost()
+    {
+        $ro = $this->resource->post('page://self/index', ['name' => 'bear']);
+        $this->assertSame('post bear', $ro->body);
+    }
+
+    public function testPut()
+    {
+        $ro = $this->resource->put('page://self/index', ['name' => 'bear']);
+        $this->assertSame('put bear', $ro->body);
+    }
+
+    public function testPatch()
+    {
+        $ro = $this->resource->patch('page://self/index', ['name' => 'bear']);
+        $this->assertSame('patch bear', $ro->body);
+    }
+
+    public function testDelete()
+    {
+        $ro = $this->resource->delete('page://self/index', ['name' => 'bear']);
+        $this->assertSame('delete bear', $ro->body);
     }
 }


### PR DESCRIPTION
This PR "adds" new resource request syntax.

Old (PHP5.x)


```php
$this->resource->post->uri('page://self/index')->withQuery(['name' => 'bear'])->eager->request();
```

Current (PHP7.x)

```php
$this->resource->post->uri('page://self/index')(['name' => 'bear']);
```

This PR
```php
$this->resource->post('page://self/index', ['name' => 'bear'])
```

`get`, `put`, `patch`, `options` and `head` also applied same.

Note: current `uri()`method is still valid as following.

```php
$createFoo = $this->resource->post->uri('page://self/foo'); // return callable object
foreach ($i = 0; $i < $max; $i++) {
    $createFoo(['id' => $id]);
}
// or you can pass as callable object with other function
```
