### PR TITLE
Add Link rel="describedby" header when schema is annotated

### DIFF
--- a/src/Anchor.php
+++ b/src/Anchor.php
@@ -9,6 +9,7 @@ namespace BEAR\Resource;
 use BEAR\Resource\Annotation\Link as LinkAnnotation;
 use BEAR\Resource\Exception\LinkException;
 use Doctrine\Common\Annotations\Reader;
+use function get_class;
 
 final class Anchor implements AnchorInterface
 {
@@ -33,7 +34,7 @@ final class Anchor implements AnchorInterface
     public function href(string $rel, AbstractRequest $request, array $query)
     {
         $classMethod = 'on' . ucfirst($request->method);
-        $annotations = $this->reader->getMethodAnnotations(new \ReflectionMethod($request->resourceObject, $classMethod));
+        $annotations = $this->reader->getMethodAnnotations(new \ReflectionMethod(get_class($request->resourceObject), $classMethod));
         foreach ($annotations as $annotation) {
             if ($this->isValidLinkAnnotation($annotation, $rel)) {
                 return $this->getMethodUdi($request, $query, $annotation);

--- a/src/Exception/InvalidSchemaUriException.php
+++ b/src/Exception/InvalidSchemaUriException.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Resource\Exception;
+
+use LogicException;
+
+class InvalidSchemaUriException extends LogicException implements ExceptionInterface
+{
+}

--- a/src/Interceptor/JsonSchemaInterceptor.php
+++ b/src/Interceptor/JsonSchemaInterceptor.php
@@ -33,15 +33,21 @@ final class JsonSchemaInterceptor implements MethodInterceptor
     private $validateDir;
 
     /**
+     * @var string
+     */
+    private $schemaHost;
+
+    /**
      * @param string $schemaDir
      * @param string $validateDir
      *
-     * @Named("schemaDir=json_schema_dir,validateDir=json_validate_dir")
+     * @Named("schemaDir=json_schema_dir,validateDir=json_validate_dir,schemaHost=json_schema_host")
      */
-    public function __construct($schemaDir, $validateDir)
+    public function __construct(string $schemaDir, string $validateDir, string $schemaHost)
     {
         $this->schemaDir = $schemaDir;
         $this->validateDir = $validateDir;
+        $this->schemaHost = $schemaHost;
     }
 
     /**
@@ -62,6 +68,7 @@ final class JsonSchemaInterceptor implements MethodInterceptor
         if ($ro->code === 200 || $ro->code == 201) {
             $this->validateResponse($jsonSchema, $ro);
         }
+        $ro->headers['Link'] = sprintf('<%s%s>; rel="describedby"', $this->schemaHost, $jsonSchema->schema);
 
         return $ro;
     }

--- a/src/Interceptor/JsonSchemaInterceptor.php
+++ b/src/Interceptor/JsonSchemaInterceptor.php
@@ -8,7 +8,6 @@ namespace BEAR\Resource\Interceptor;
 
 use BEAR\Resource\Annotation\JsonSchema;
 use BEAR\Resource\Code;
-use BEAR\Resource\Exception\InvalidSchemaUriException;
 use BEAR\Resource\Exception\JsonSchemaErrorException;
 use BEAR\Resource\Exception\JsonSchemaException;
 use BEAR\Resource\Exception\JsonSchemaNotFoundException;
@@ -35,7 +34,7 @@ final class JsonSchemaInterceptor implements MethodInterceptor
     private $validateDir;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $schemaHost;
 
@@ -49,9 +48,6 @@ final class JsonSchemaInterceptor implements MethodInterceptor
     {
         $this->schemaDir = $schemaDir;
         $this->validateDir = $validateDir;
-        if (is_string($schemaHost) && ! filter_var($schemaHost, FILTER_VALIDATE_URL)) {
-            throw new InvalidSchemaUriException($schemaHost);
-        }
         $this->schemaHost = $schemaHost;
     }
 

--- a/src/Linker.php
+++ b/src/Linker.php
@@ -10,6 +10,7 @@ use BEAR\Resource\Annotation\Link;
 use BEAR\Resource\Exception\LinkQueryException;
 use BEAR\Resource\Exception\LinkRelException;
 use Doctrine\Common\Annotations\Reader;
+use function get_class;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -109,7 +110,7 @@ final class Linker implements LinkerInterface
             throw new Exception\LinkQueryException('Only array is allowed for link in ' . get_class($current), 500);
         }
         $classMethod = 'on' . ucfirst($request->method);
-        $annotations = $this->reader->getMethodAnnotations(new \ReflectionMethod($current, $classMethod));
+        $annotations = $this->reader->getMethodAnnotations(new \ReflectionMethod(get_class($current), $classMethod));
         if ($link->type === LinkType::CRAWL_LINK) {
             return $this->annotationCrawl($annotations, $link, $current);
         }

--- a/src/Module/ImportAppModule.php
+++ b/src/Module/ImportAppModule.php
@@ -26,11 +26,7 @@ class ImportAppModule extends AbstractModule
      */
     private $defaultContextName;
 
-    /**
-     * @param array  $importApps
-     * @param string $defaultContextName
-     */
-    public function __construct(array $importApps, $defaultContextName = '')
+    public function __construct(array $importApps, string $defaultContextName = '')
     {
         foreach ($importApps as $importApp) {
             // create import config

--- a/src/Module/ImportSchemeCollectionProvider.php
+++ b/src/Module/ImportSchemeCollectionProvider.php
@@ -32,14 +32,10 @@ class ImportSchemeCollectionProvider implements ProviderInterface
     private $injector;
 
     /**
-     * @param string            $appName
-     * @param array             $importAppConfig
-     * @param InjectorInterface $injector
-     *
      * @AppName("appName")
      * @ImportAppConfig("importAppConfig")
      */
-    public function __construct($appName, array $importAppConfig, InjectorInterface $injector)
+    public function __construct(string $appName, array $importAppConfig, InjectorInterface $injector)
     {
         $this->appName = $appName;
         $this->importAppConfig = $importAppConfig;

--- a/src/Module/JsonSchemaLinkHeaderModule.php
+++ b/src/Module/JsonSchemaLinkHeaderModule.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Resource\Module;
+
+use BEAR\Resource\Exception\InvalidSchemaUriException;
+use Ray\Di\AbstractModule;
+
+class JsonSchemaLinkHeaderModule extends AbstractModule
+{
+    /**
+     * @var string
+     */
+    private $jsonSchemaHost;
+
+    /**
+     * @param string              $jsonSchemaHost Json-schema host name ex) https://example.com/schema/
+     * @param AbstractModule|null $module
+     */
+    public function __construct(
+        string $jsonSchemaHost,
+        AbstractModule $module = null
+    ) {
+        $this->jsonSchemaHost = $jsonSchemaHost;
+        if (! filter_var($jsonSchemaHost, FILTER_VALIDATE_URL)) {
+            throw new InvalidSchemaUriException($jsonSchemaHost);
+        }
+
+        parent::__construct($module);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->bind()->annotatedWith('json_schema_host')->toInstance($this->jsonSchemaHost);
+    }
+}

--- a/src/Module/JsonSchemaModule.php
+++ b/src/Module/JsonSchemaModule.php
@@ -29,8 +29,6 @@ class JsonSchemaModule extends AbstractModule
     private $jsonSchemaHost;
 
     /**
-     * JsonSchemaModule constructor.
-     *
      * @param string              $jsonSchemaDir   Json-schema json file directory
      * @param string              $jsonValidateDir Json-schema validator json file directory
      * @param string              $jsonSchemaHost  Json-schema host name ex) https://example.com/schema/

--- a/src/Module/JsonSchemaModule.php
+++ b/src/Module/JsonSchemaModule.php
@@ -14,23 +14,37 @@ use Ray\Di\AbstractModule;
 class JsonSchemaModule extends AbstractModule
 {
     /**
-     * Json-schema json file directory
-     *
      * @var string
      */
     private $jsonSchemaDir;
 
     /**
-     * Json-schema validator json file directory
-     *
      * @var string
      */
     private $jsonValidateDir;
 
-    public function __construct($jsonSchemaDir = '', $jsonValidateDir = '', AbstractModule $module = null)
-    {
+    /**
+     * @var string
+     */
+    private $jsonSchemaHost;
+
+    /**
+     * JsonSchemaModule constructor.
+     *
+     * @param string              $jsonSchemaDir   Json-schema json file directory
+     * @param string              $jsonValidateDir Json-schema validator json file directory
+     * @param string              $jsonSchemaHost  Json-schema host name ex) https://example.com/schema/
+     * @param AbstractModule|null $module
+     */
+    public function __construct(
+        string $jsonSchemaDir = '',
+        string $jsonValidateDir = '',
+        string $jsonSchemaHost = '',
+        AbstractModule $module = null
+    ){
         $this->jsonSchemaDir = $jsonSchemaDir;
         $this->jsonValidateDir = $jsonValidateDir;
+        $this->jsonSchemaHost = $jsonSchemaHost;
         parent::__construct($module);
     }
 
@@ -41,6 +55,8 @@ class JsonSchemaModule extends AbstractModule
     {
         $this->bind()->annotatedWith('json_schema_dir')->toInstance($this->jsonSchemaDir);
         $this->bind()->annotatedWith('json_validate_dir')->toInstance($this->jsonValidateDir);
+        $this->bind()->annotatedWith('json_schema_host')->toInstance($this->jsonSchemaHost);
+
         $this->bindInterceptor(
             $this->matcher->subclassesOf(ResourceObject::class),
             $this->matcher->annotatedWith(JsonSchema::class),

--- a/src/Module/JsonSchemaModule.php
+++ b/src/Module/JsonSchemaModule.php
@@ -24,25 +24,17 @@ class JsonSchemaModule extends AbstractModule
     private $jsonValidateDir;
 
     /**
-     * @var string
-     */
-    private $jsonSchemaHost;
-
-    /**
      * @param string              $jsonSchemaDir   Json-schema json file directory
      * @param string              $jsonValidateDir Json-schema validator json file directory
-     * @param string              $jsonSchemaHost  Json-schema host name ex) https://example.com/schema/
      * @param AbstractModule|null $module
      */
     public function __construct(
         string $jsonSchemaDir = '',
         string $jsonValidateDir = '',
-        string $jsonSchemaHost = '',
         AbstractModule $module = null
     ) {
         $this->jsonSchemaDir = $jsonSchemaDir;
         $this->jsonValidateDir = $jsonValidateDir;
-        $this->jsonSchemaHost = $jsonSchemaHost;
         parent::__construct($module);
     }
 
@@ -53,7 +45,6 @@ class JsonSchemaModule extends AbstractModule
     {
         $this->bind()->annotatedWith('json_schema_dir')->toInstance($this->jsonSchemaDir);
         $this->bind()->annotatedWith('json_validate_dir')->toInstance($this->jsonValidateDir);
-        $this->bind()->annotatedWith('json_schema_host')->toInstance($this->jsonSchemaHost);
 
         $this->bindInterceptor(
             $this->matcher->subclassesOf(ResourceObject::class),

--- a/src/Module/JsonSchemaModule.php
+++ b/src/Module/JsonSchemaModule.php
@@ -41,7 +41,7 @@ class JsonSchemaModule extends AbstractModule
         string $jsonValidateDir = '',
         string $jsonSchemaHost = '',
         AbstractModule $module = null
-    ){
+    ) {
         $this->jsonSchemaDir = $jsonSchemaDir;
         $this->jsonValidateDir = $jsonValidateDir;
         $this->jsonSchemaHost = $jsonSchemaHost;

--- a/src/Module/ResourceModule.php
+++ b/src/Module/ResourceModule.php
@@ -17,9 +17,9 @@ class ResourceModule extends AbstractModule
     private $appName;
 
     /**
-     * @param string $appName
+     * @param string $appName Application name ex) 'Vendor\Project'
      */
-    public function __construct($appName)
+    public function __construct(string $appName)
     {
         $this->appName = $appName;
         parent::__construct();

--- a/src/OptionsMethods.php
+++ b/src/OptionsMethods.php
@@ -49,7 +49,7 @@ final class OptionsMethods
 
     public function __invoke(ResourceObject $ro, string $requestMethod) : array
     {
-        $method = new \ReflectionMethod($ro, 'on' . $requestMethod);
+        $method = new \ReflectionMethod(get_class($ro), 'on' . $requestMethod);
         $ins = $this->getInMap($method);
         list($doc, $paramDoc) = (new OptionsMethodDocBolck)($method);
         $paramMetas = (new OptionsMethodRequest($this->reader))($method, $paramDoc, $ins);

--- a/tests/Module/JsonSchemaModuleTest.php
+++ b/tests/Module/JsonSchemaModuleTest.php
@@ -20,14 +20,14 @@ class JsonSchemaModuleTest extends TestCase
 {
     public function testValid()
     {
-        $ro = $this->getFakeUser();
+        $ro = $this->getRo(FakeUser::class);
         $ro->onGet(20);
         $this->assertSame($ro->body['name']['firstName'], 'mucha');
     }
 
     public function testValidArrayRef()
     {
-        $ro = $this->getFakeUsers();
+        $ro = $this->getRo(FakeUsers::class);
         $ro->onGet(20);
         $this->assertSame($ro->body[0]['name']['firstName'], 'mucha');
     }
@@ -109,16 +109,6 @@ class JsonSchemaModuleTest extends TestCase
         } catch (JsonSchemaException $e) {
             return $e;
         }
-    }
-
-    private function getFakeUser() : FakeUser
-    {
-        return $this->getRo(FakeUser::class);
-    }
-
-    private function getFakeUsers() : FakeUsers
-    {
-        return $this->getRo(FakeUsers::class);
     }
 
     private function getRo(string $class)

--- a/tests/Module/JsonSchemaModuleTest.php
+++ b/tests/Module/JsonSchemaModuleTest.php
@@ -113,7 +113,7 @@ class JsonSchemaModuleTest extends TestCase
 
     private function getRo(string $class)
     {
-        $module = $this->getModule();
+        $module = $this->getJsonSchemaModule();
         $ro = (new Injector($module, $_ENV['TMP_DIR']))->getInstance($class);
         /* @var $ro FakeUser */
         $ro->uri = new Uri('app://self/user?id=1');
@@ -124,7 +124,7 @@ class JsonSchemaModuleTest extends TestCase
     private function getLinkHeaderRo(string $class)
     {
         $jsonSchemaHost = 'http://example.com/schema/';
-        $module = $this->getModule();
+        $module = $this->getJsonSchemaModule();
         $module->install(new JsonSchemaLinkHeaderModule($jsonSchemaHost));
         $ro = (new Injector($module, $_ENV['TMP_DIR']))->getInstance($class);
         /* @var $ro FakeUser */
@@ -133,12 +133,11 @@ class JsonSchemaModuleTest extends TestCase
         return $ro;
     }
 
-    private function getModule() : JsonSchemaModule
+    private function getJsonSchemaModule() : JsonSchemaModule
     {
         $jsonSchema = dirname(__DIR__) . '/Fake/json_schema';
         $jsonValidate = dirname(__DIR__) . '/Fake/json_validate';
-        $module = new JsonSchemaModule($jsonSchema, $jsonValidate);
 
-        return $module;
+        return new JsonSchemaModule($jsonSchema, $jsonValidate);
     }
 }

--- a/tests/Module/JsonSchemaModuleTest.php
+++ b/tests/Module/JsonSchemaModuleTest.php
@@ -23,6 +23,7 @@ class JsonSchemaModuleTest extends TestCase
         $ro = $this->getFakeUser();
         $ro->onGet(20);
         $this->assertSame($ro->body['name']['firstName'], 'mucha');
+        $this->assertSame('<http://example.com/schema/user.json>; rel="describedby"', $ro->headers['Link']);
     }
 
     public function testValidArrayRef()
@@ -119,7 +120,8 @@ class JsonSchemaModuleTest extends TestCase
     {
         $jsonSchema = dirname(__DIR__) . '/Fake/json_schema';
         $jsonValidate = dirname(__DIR__) . '/Fake/json_validate';
-        $ro = (new Injector(new JsonSchemaModule($jsonSchema, $jsonValidate), $_ENV['TMP_DIR']))->getInstance($class);
+        $jsonSchemaHost = 'http://example.com/schema/';
+        $ro = (new Injector(new JsonSchemaModule($jsonSchema, $jsonValidate, $jsonSchemaHost), $_ENV['TMP_DIR']))->getInstance($class);
         /* @var $ro FakeUser */
         $ro->uri = new Uri('app://self/user?id=1');
 


### PR DESCRIPTION
概要

`@JsonSchema`とアノテートされていると[JSON Schema: A Media Type for Describing JSON Documents](http://json-schema.org/latest/json-schema-core.html#rfc.section.10.1)[日本語](https://github.com/nasa9084/json-schema-ja)で`recommended`とされているLinkヘッダーが付与されます。

APIが自己記述的になり、API利用者はAPIのスペックに確信が持てます。

When `@JsonSchema` is annotated as following,

```php
/**
 * @JsonSchema(schema="tickets.json")
 */
public function onGet() : ResourceObject
{
```

... and downloadable JSON schema public URI is provided in the third parameter of JsonSchemaModule,

```php
$this->install(new JsonSchemaLinkHeaderModule('http://example.com/schema/'));
```

Link header is added as follows.

```
$ curl -i http://127.0.0.1:8080/tickets
HTTP/1.1 200 OK
...
Link: <http://example.com/schema/tickets.json>; rel="describedby"
content-type: application/hal+json
ETag: 2101138260
Last-Modified: Tue, 04 Sep 2018 03:34:12 GMT
{
```

Source:

http://json-schema.org/latest/json-schema-core.html#rfc.section.10.1


>It is RECOMMENDED that instances described by a schema provide a link to a downloadable JSON Schema using the link relation "describedby", as defined by Linked Data Protocol 1.0, section 8.1 [W3C.REC-ldp-20150226].
In HTTP, such links can be attached to any response using the Link header [RFC8288]. An example of such a header would be:


```
Link: <http://example.com/my-hyper-schema#>; rel="describedby"
```
