### PR TITLE
Generate FakeJson response on the fly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
 
 before_install:
   - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"
+  - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
   - composer self-update
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -26,14 +26,21 @@
         "koriym/http-constants": "^1.0",
         "ray/web-param-module": "^2.0",
         "justinrainbow/json-schema": "^5.2",
-        "bear/cs": "^1.0"
+        "bear/cs": "^1.0",
+        "leko/json-schema-faker": "dev-ref-schema"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.2",
         "vimeo/psalm": "^2.0",
         "phpstan/phpstan-shim": "^0.9"
     },
-    "autoload": {
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/koriym/php-json-schema-faker"
+        }
+    ],
+      "autoload": {
         "psr-4": {
             "BEAR\\Resource\\": ["src/", "src-deprecated"]
         },

--- a/src/Interceptor/JsonSchemaInterceptor.php
+++ b/src/Interceptor/JsonSchemaInterceptor.php
@@ -10,9 +10,12 @@ use BEAR\Resource\Exception\JsonSchemaErrorException;
 use BEAR\Resource\Exception\JsonSchemaException;
 use BEAR\Resource\Exception\JsonSchemaNotFoundException;
 use BEAR\Resource\ResourceObject;
+use function file_get_contents;
 use function is_string;
+use function json_decode;
 use JsonSchema\Constraints\Constraint;
 use JsonSchema\Validator;
+use JSONSchemaFaker\Faker;
 use Ray\Aop\MethodInterceptor;
 use Ray\Aop\MethodInvocation;
 use Ray\Aop\ReflectionMethod;
@@ -21,6 +24,8 @@ use Ray\Di\Di\Named;
 
 final class JsonSchemaInterceptor implements MethodInterceptor
 {
+    const X_FAKE_JSON = 'X-Fake-JSON';
+
     /**
      * @var string
      */
@@ -37,13 +42,19 @@ final class JsonSchemaInterceptor implements MethodInterceptor
     private $schemaHost;
 
     /**
-     * @Named("schemaDir=json_schema_dir,validateDir=json_validate_dir,schemaHost=json_schema_host")
+     * @var bool
      */
-    public function __construct(string $schemaDir, string $validateDir, string $schemaHost = null)
+    private $enableFakeJson;
+
+    /**
+     * @Named("schemaDir=json_schema_dir,validateDir=json_validate_dir,schemaHost=json_schema_host,enableFakeJson=enable_fake_json")
+     */
+    public function __construct(string $schemaDir, string $validateDir, string $schemaHost = null, bool $enableFakeJson = false)
     {
         $this->schemaDir = $schemaDir;
         $this->validateDir = $validateDir;
         $this->schemaHost = $schemaHost;
+        $this->enableFakeJson = $enableFakeJson;
     }
 
     /**
@@ -61,14 +72,46 @@ final class JsonSchemaInterceptor implements MethodInterceptor
         }
         /** @var ResourceObject $ro */
         $ro = $invocation->proceed();
-        if ($ro->code === 200 || $ro->code == 201) {
-            $this->validateResponse($jsonSchema, $ro);
-        }
         if (is_string($this->schemaHost)) {
             $ro->headers['Link'] = sprintf('<%s%s>; rel="describedby"', $this->schemaHost, $jsonSchema->schema);
         }
+        if ($ro->code !== 200 && $ro->code !== 201) {
+            return $ro;
+        }
+        try {
+            $this->validateResponse($jsonSchema, $ro);
+        } catch (JsonSchemaException $e) {
+            if ($this->enableFakeJson) {
+                $ro->headers[self::X_FAKE_JSON] = $jsonSchema->schema;
+                $ro->body = $this->fakeResponse($jsonSchema);
+
+                return $ro;
+            }
+
+            throw $e;
+        }
 
         return $ro;
+    }
+
+    private function fakeResponse(JsonSchema $jsonSchema) : array
+    {
+        $schemaFile = $this->schemaDir . '/' . $jsonSchema->schema;
+        $this->validateFileExists($schemaFile);
+        $schema = json_decode(file_get_contents($schemaFile));
+        $fakeJson = (new Faker($this->schemaDir))->generate($schema);
+
+        return $this->deepArray($fakeJson);
+    }
+
+    private function deepArray($values) : array
+    {
+        $result = [];
+        foreach ($values as $key => $value) {
+            $result[$key] = is_object($value) ? $this->deepArray((array) $value) : $result[$key] = $value;
+        }
+
+        return $result;
     }
 
     private function validateRequest(JsonSchema $jsonSchema, array $arguments)

--- a/src/Module/FakeJsonModule.php
+++ b/src/Module/FakeJsonModule.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\Module;
+
+use Ray\Di\AbstractModule;
+
+class FakeJsonModule extends AbstractModule
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->bind()->annotatedWith('enable_fake_json')->toInstance(true);
+    }
+}

--- a/tests/Fake/JsonSchema/FakeVoidUser.php
+++ b/tests/Fake/JsonSchema/FakeVoidUser.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Resource\JsonSchema;
+
+use BEAR\Resource\Annotation\JsonSchema;
+use BEAR\Resource\Code;
+use BEAR\Resource\ResourceObject;
+
+class FakeVoidUser extends ResourceObject
+{
+    /**
+     * @JsonSchema(schema="user.json", params="user.get.json")
+     * {@SuppressWarnings("unused")}
+     */
+    public function onGet(int $age, string $gender = 'male')
+    {
+        unset($age);
+        unset($gender);
+
+        return $this;
+    }
+
+    /**
+     * @JsonSchema(schema="__invalid.json")
+     */
+    public function onPost()
+    {
+        return $this;
+    }
+
+    /**
+     * @JsonSchema(schema="definitions/user.json")
+     */
+    public function onPut()
+    {
+        $this->code = Code::NO_CONTENT;
+        $this->body = [];
+
+        return $this;
+    }
+
+    /**
+     * @JsonSchema(params="__invalid.json")
+     */
+    public function onPatch()
+    {
+        return $this;
+    }
+}

--- a/tests/Fake/JsonSchema/FakeVoidUsers.php
+++ b/tests/Fake/JsonSchema/FakeVoidUsers.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Resource\JsonSchema;
+
+use BEAR\Resource\Annotation\JsonSchema;
+use BEAR\Resource\ResourceObject;
+
+class FakeVoidUsers extends ResourceObject
+{
+    /**
+     * @JsonSchema(schema="users.json")
+     */
+    public function onGet(int $age)
+    {
+        return $this;
+    }
+}

--- a/tests/Fake/json_schema/users.json
+++ b/tests/Fake/json_schema/users.json
@@ -3,6 +3,7 @@
   "type": "array",
   "items": {
     "$ref": "user.json"
-  }
+  },
+  "minItems": 1
 }
 

--- a/tests/Module/JsonSchemaFakeModuleTest.php
+++ b/tests/Module/JsonSchemaFakeModuleTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\Module;
+
+use BEAR\Resource\Exception\JsonSchemaException;
+use BEAR\Resource\Exception\JsonSchemaNotFoundException;
+use BEAR\Resource\Interceptor\JsonSchemaInterceptor;
+use BEAR\Resource\JsonSchema\FakeUser;
+use BEAR\Resource\JsonSchema\FakeVoidUser;
+use BEAR\Resource\JsonSchema\FakeVoidUsers;
+use BEAR\Resource\ResourceObject;
+use BEAR\Resource\Uri;
+use PHPUnit\Framework\TestCase;
+use Ray\Di\Injector;
+
+class JsonSchemaFakeModuleTest extends TestCase
+{
+    public function testValid()
+    {
+        $ro = $this->getRo(FakeVoidUser::class);
+        $ro->onGet(20);
+        $this->assertSame($ro->headers[JsonSchemaInterceptor::X_FAKE_JSON], 'user.json');
+        $this->assertInternalType('string', $ro->body['name']['firstName']);
+    }
+
+    public function testValidArrayRef()
+    {
+        $ro = $this->getRo(FakeVoidUsers::class);
+        $ro->onGet(20);
+        $this->assertSame($ro->headers[JsonSchemaInterceptor::X_FAKE_JSON], 'users.json');
+        $this->assertInternalType('string', $ro->body[0]['name']['firstName']);
+    }
+
+    /**
+     * @depends testValidateException
+     */
+    public function testBCValidateErrorException(JsonSchemaException $e)
+    {
+        $errors = [];
+        while ($e = $e->getPrevious()) {
+            $errors[] = $e->getMessage();
+        }
+        $expected = ['[age] Must have a minimum value of 20'];
+        $this->assertSame($expected, $errors);
+    }
+
+    public function testException()
+    {
+        $this->expectException(JsonSchemaNotFoundException::class);
+        $ro = $this->getRo(FakeUser::class);
+        $ro->onPost();
+    }
+
+    public function testParameterException()
+    {
+        $caughtException = null;
+        $ro = $this->getRo(FakeUser::class);
+        try {
+            $ro->onGet(30, 'invalid gender');
+        } catch (JsonSchemaException $e) {
+            $caughtException = $e;
+        }
+        $this->assertEmpty($ro->body);
+        $this->assertInstanceOf(JsonSchemaException::class, $caughtException);
+    }
+
+    public function testWorksOnlyCode200()
+    {
+        $ro = $this->getRo(FakeUser::class);
+        $ro->onPut();
+        $this->assertInstanceOf(ResourceObject::class, $ro);
+    }
+
+    public function invalidRequestTest()
+    {
+        $this->expectException(JsonSchemaNotFoundException::class);
+        $ro = $this->getRo(FakeUser::class);
+        $ro->onPatch();
+    }
+
+    public function linkHeaderTest()
+    {
+        $ro = $this->getLinkHeaderRo(FakeUser::class);
+        $this->assertSame('<http://example.com/schema/user.json>; rel="describedby"', $ro->headers['Link']);
+    }
+
+    private function createJsonSchemaException($class)
+    {
+        $ro = $this->getRo($class);
+        try {
+            $ro->onGet(10);
+        } catch (JsonSchemaException $e) {
+            return $e;
+        }
+    }
+
+    private function getRo(string $class)
+    {
+        $module = $this->getJsonSchemaModule();
+        $ro = (new Injector($module, $_ENV['TMP_DIR']))->getInstance($class);
+        /* @var $ro FakeUser */
+        $ro->uri = new Uri('app://self/user?id=1');
+
+        return $ro;
+    }
+
+    private function getLinkHeaderRo(string $class)
+    {
+        $jsonSchemaHost = 'http://example.com/schema/';
+        $module = $this->getJsonSchemaModule();
+        $module->install(new JsonSchemaLinkHeaderModule($jsonSchemaHost));
+        $ro = (new Injector($module, $_ENV['TMP_DIR']))->getInstance($class);
+        /* @var $ro FakeUser */
+        $ro->uri = new Uri('app://self/user?id=1');
+
+        return $ro;
+    }
+
+    private function getJsonSchemaModule() : JsonSchemaModule
+    {
+        $jsonSchema = dirname(__DIR__) . '/Fake/json_schema';
+        $jsonValidate = dirname(__DIR__) . '/Fake/json_validate';
+
+        return new JsonSchemaModule($jsonSchema, $jsonValidate, new FakeJsonModule);
+    }
+}


### PR DESCRIPTION
Generated fake response when JSON schema validation failed and FakeJsonModule installed.

 * Mocking with JSON schema.
 * FakeResponse is also validated.
 * `X-Fake-JSON` header is served when the fake response is generated
 * Fake response only when the validation failed, otherwise "real return value" is responded.

```php
$this->install(new FakeJsonModule);
```

開発時にリソースのメソッドが未実装でも`@JsonSchema`でスキーマが指定されていれば、そのスキーマからダミーのレスポンスを生成します。モックサーバー用途。
