### PR TITLE
Try CamelCase var name when request parameter matching failed

### DIFF
--- a/src/OptionalParam.php
+++ b/src/OptionalParam.php
@@ -24,6 +24,11 @@ final class OptionalParam implements ParamInterface
         if (isset($query[$varName])) {
             return $query[$varName];
         }
+        // try camelCase variable name
+        $snakeName = ltrim(strtolower(preg_replace('/[A-Z]/', '_\0', $varName)), '_');
+        if (isset($query[$snakeName])) {
+            return $query[$snakeName];
+        }
 
         return $this->defaultValue;
     }

--- a/src/RequiredParam.php
+++ b/src/RequiredParam.php
@@ -14,10 +14,15 @@ final class RequiredParam implements ParamInterface
      */
     public function __invoke(string $varName, array $query, InjectorInterface $injector)
     {
-        unset($injector);
         if (isset($query[$varName])) {
             return $query[$varName];
         }
+        // try camelCase variable name
+        $snakeName = ltrim(strtolower(preg_replace('/[A-Z]/', '_\0', $varName)), '_');
+        if (isset($query[$snakeName])) {
+            return $query[$snakeName];
+        }
+        unset($injector);
 
         throw new ParameterException($varName);
     }

--- a/tests/Fake/FakeCamelCaseParamResource.php
+++ b/tests/Fake/FakeCamelCaseParamResource.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Resource;
+
+class FakeCamelCaseParamResource extends ResourceObject
+{
+    public function onGet(string $userId, string $userRole = '')
+    {
+        $this->body = [
+            'userId' => $userId,
+            'userRole' => $userRole
+        ];
+
+        return $this;
+    }
+}

--- a/tests/NamedParameterTest.php
+++ b/tests/NamedParameterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BEAR\Resource;
 
 use BEAR\Resource\Exception\ParameterException;
+use function call_user_func_array;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Cache\ArrayCache;
 use PHPUnit\Framework\TestCase;
@@ -94,5 +95,15 @@ class NamedParameterTest extends TestCase
         AssistedWebContextParam::setSuperGlobalsOnlyForTestingPurpose([]);
         $object = new FakeParamResource;
         $args = $this->params->getParameters([$object, 'onDelete'], []);
+    }
+
+    public function testCameCaseParam()
+    {
+        $object = new FakeCamelCaseParamResource;
+        $namedArgs = ['user_id' => 'koriym', 'user_role' => 'lead'];
+        $args = $this->params->getParameters([$object, 'onGet'], $namedArgs);
+        $this->assertSame(['koriym', 'lead'], $args);
+        $ro = call_user_func_array([$object, 'onGet'], $args);
+        $this->assertSame(['userId' => 'koriym', 'userRole' => 'lead'], (array) $ro->body);
     }
 }


### PR DESCRIPTION
camelCase parameters in ResourceObject method can be called snake_case query parameter.

`?usser_id=1` can call`onGet($userId)` method.

キャメルケースの変数名をもつResourceObjectのメソッドを、 スネークケースの名前付き変数でコールする事ができます。snakeケースでもcamelCaseでも同じようにコールできます。

`CamelCaseKeyModule`と組み合わせるとコールはやデータベースはsnakeケース、PHPの引数やJSON出力時のキーはcamelCaseになります。

```php
 $this->install(new CamelCaseKeyModule);
```

```php
class Work extends ResourceObject
{
    public function onGet($userId) : ResourceObject
    {
        $this->body = ['snake_id' => $userId];
        return $this;
    }
}
```
```
php bin/app.php get /work?user_id=1
200 OK
content-type: application/hal+json

{
    "snakeId": "1",
    "_links": {
        "self": {
            "href": "/work?user_id=1"
        }
    }
}
```