### PR TITLE
ResourceObject class parameter

### DIFF
--- a/src/ClassParam.php
+++ b/src/ClassParam.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource;
+
+use BEAR\Resource\Exception\ParameterException;
+use Ray\Di\InjectorInterface;
+use ReflectionClass;
+
+final class ClassParam implements ParamInterface
+{
+    /**
+     * @var ReflectionClass
+     */
+    private $class;
+
+    /**
+     * @var \ReflectionParameter
+     */
+    private $parameter;
+
+    public function __construct(ReflectionClass $class, \ReflectionParameter $parameter)
+    {
+        $this->class = $class;
+        $this->parameter = $parameter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __invoke(string $varName, array $query, InjectorInterface $injector)
+    {
+        try {
+            $props = $this->getProps($varName, $query, $injector);
+        } catch (ParameterException $e) {
+            if ($this->parameter->isDefaultValueAvailable()) {
+                return $this->parameter->getDefaultValue();
+            }
+
+            throw $e;
+        }
+        $obj = $this->class->newInstanceWithoutConstructor();
+        foreach ($props as $propName => $propValue) {
+            $obj->{$propName} = $propValue;
+        }
+
+        return $obj;
+    }
+
+    private function getProps(string $varName, array $query, InjectorInterface $injector) : array
+    {
+        if (isset($query[$varName])) {
+            return $query[$varName];
+        }
+        // try camelCase variable name
+        $snakeName = ltrim(strtolower(preg_replace('/[A-Z]/', '_\0', $varName)), '_');
+        if (isset($query[$snakeName])) {
+            return $query[$snakeName];
+        }
+
+        unset($injector);
+
+        throw new ParameterException($varName);
+    }
+}

--- a/src/NamedParamMetas.php
+++ b/src/NamedParamMetas.php
@@ -119,6 +119,11 @@ final class NamedParamMetas implements NamedParamMetasInterface
 
     private function getParam(\ReflectionParameter $parameter) : ParamInterface
     {
+        $class = $parameter->getClass();
+        if ($class instanceof \ReflectionClass) {
+            return new ClassParam($class, $parameter);
+        }
+
         return $parameter->isDefaultValueAvailable() === true ? new OptionalParam($parameter->getDefaultValue()) : new RequiredParam;
     }
 }

--- a/tests/Fake/Mock/Json.php
+++ b/tests/Fake/Mock/Json.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Resource\Mock;
+
+use BEAR\Resource\ResourceObject;
+
+class Json extends ResourceObject
+{
+    public function onGet(Person $person)
+    {
+        $this->body = $person;
+
+        return $this;
+    }
+}

--- a/tests/Fake/Mock/Person.php
+++ b/tests/Fake/Mock/Person.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Resource\Mock;
+
+class Person
+{
+    public $name;
+    public $age;
+}

--- a/tests/InvokerTest.php
+++ b/tests/InvokerTest.php
@@ -8,6 +8,7 @@ use BEAR\Resource\Exception\MethodNotAllowedException;
 use BEAR\Resource\Exception\ParameterException;
 use BEAR\Resource\Interceptor\FakeLogInterceptor;
 use BEAR\Resource\Mock\Comment;
+use BEAR\Resource\Mock\Json;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Cache\ArrayCache;
 use FakeVendor\Sandbox\Resource\App\Doc;
@@ -217,5 +218,14 @@ class InvokerTest extends TestCase
         $invoker = new Invoker(new NamedParameter(new NamedParamMetas(new ArrayCache, new AnnotationReader), new Injector), new VoidOptionsRenderer);
         $request = new Request($this->invoker, new Order, Request::DELETE);
         $invoker->invoke($request);
+    }
+
+    public function testInvokeClassTyped()
+    {
+        $person = ['age' => 28, 'name' => 'monsley'];
+        $request = new Request($this->invoker, new Json, Request::GET, ['person' => $person]);
+        $actual = $this->invoker->invoke($request)->body;
+        $this->assertSame($actual->name, 'monsley');
+        $this->assertSame($actual->age, 28);
     }
 }


### PR DESCRIPTION
連想配列でコールすると、変数の型のオブジェクトに変換されます。

JSONスキーマをPHPのクラスにしておくと以下の様に変換されます。

```php

final class User
{
    public $name;
    public $age
}
```

```
get /foo?user%5Bname%5D=bear
```

```php
public function onGet(User $user)
{
    var_dump($user->name) // bear 
}
```