### PR TITLE
Schema and host name is optionable in resource uri() or {method}() method

### DIFF
--- a/src/Annotation/ContextSchema.php
+++ b/src/Annotation/ContextSchema.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\Annotation;
+
+use Ray\Di\Di\Qualifier;
+
+/**
+ * @Annotation
+ * @Target("METHOD")
+ * @Qualifier
+ */
+final class ContextSchema
+{
+    public $value;
+}

--- a/src/Linker.php
+++ b/src/Linker.php
@@ -37,14 +37,21 @@ final class Linker implements LinkerInterface
      */
     private $cache = [];
 
+    /**
+     * @var UriFactory
+     */
+    private $uri;
+
     public function __construct(
         Reader $reader,
         InvokerInterface $invoker,
-        FactoryInterface $factory
+        FactoryInterface $factory,
+        UriFactory $uri
     ) {
         $this->reader = $reader;
         $this->invoker = $invoker;
         $this->factory = $factory;
+        $this->uri = $uri;
     }
 
     /**
@@ -133,7 +140,7 @@ final class Linker implements LinkerInterface
             $uri = uri_template($annotation->href, $current->body);
             $rel = $this->factory->newInstance($uri);
             /* @noinspection UnnecessaryParenthesesInspection */
-            $request = new Request($this->invoker, $rel, Request::GET, (new Uri($uri))->query);
+            $request = new Request($this->invoker, $rel, Request::GET, (($this->uri)($uri))->query);
 
             return $this->invoker->invoke($request);
         }
@@ -176,7 +183,7 @@ final class Linker implements LinkerInterface
             $uri = uri_template($annotation->href, $body);
             $rel = $this->factory->newInstance($uri);
             /* @noinspection UnnecessaryParenthesesInspection */
-            $request = new Request($this->invoker, $rel, Request::GET, (new Uri($uri))->query, [$link], $this);
+            $request = new Request($this->invoker, $rel, Request::GET, (($this->uri)($uri))->query, [$link], $this);
             $hash = $request->hash();
             if (array_key_exists($hash, $this->cache)) {
                 $body[$annotation->rel] = $this->cache[$hash];

--- a/src/Module/ResourceClientModule.php
+++ b/src/Module/ResourceClientModule.php
@@ -23,6 +23,7 @@ use BEAR\Resource\RenderInterface;
 use BEAR\Resource\Resource;
 use BEAR\Resource\ResourceInterface;
 use BEAR\Resource\SchemeCollectionInterface;
+use BEAR\Resource\UriFactory;
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\Cache;
 use Ray\Di\AbstractModule;
@@ -40,6 +41,7 @@ class ResourceClientModule extends AbstractModule
      */
     protected function configure()
     {
+        $this->bind(UriFactory::class);
         $this->bind(ResourceInterface::class)->to(Resource::class)->in(Scope::SINGLETON);
         $this->bind(InvokerInterface::class)->to(Invoker::class);
         $this->bind(LinkerInterface::class)->to(Linker::class);

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -55,6 +55,11 @@ final class Resource implements ResourceInterface
      */
     private $method = 'get';
 
+    /**
+     * @var UriFactory
+     */
+    private $uri;
+
     /** @noinspection MoreThanThreeArgumentsInspection */
 
     /**
@@ -62,17 +67,20 @@ final class Resource implements ResourceInterface
      * @param InvokerInterface $invoker Resource request invoker
      * @param AnchorInterface  $anchor  Resource anchor
      * @param LinkerInterface  $linker  Resource linker
+     * @param UriFactory       $uri     URI factory
      */
     public function __construct(
         FactoryInterface $factory,
         InvokerInterface $invoker,
         AnchorInterface  $anchor,
-        LinkerInterface  $linker
+        LinkerInterface  $linker,
+        UriFactory $uri
     ) {
         $this->factory = $factory;
         $this->invoker = $invoker;
         $this->anchor = $anchor;
         $this->linker = $linker;
+        $this->uri = $uri;
     }
 
     /**
@@ -111,7 +119,7 @@ final class Resource implements ResourceInterface
     public function uri($uri) : RequestInterface
     {
         if (is_string($uri)) {
-            $uri = new Uri($uri);
+            $uri = ($this->uri)($uri);
         }
         $uri->method = $this->method;
         $ro = $this->newInstance($uri);
@@ -136,48 +144,50 @@ final class Resource implements ResourceInterface
     {
         $this->method = Request::GET;
 
-        return $this->uri(new Uri($uri))($query);
+        ($this->uri)($uri);
+
+        return $this->uri(($this->uri)($uri))($query);
     }
 
     public function post(string $uri, array $query = []) : ResourceObject
     {
         $this->method = Request::POST;
 
-        return $this->uri(new Uri($uri))($query);
+        return $this->uri(($this->uri)($uri))($query);
     }
 
     public function put(string $uri, array $query = []) : ResourceObject
     {
         $this->method = Request::PUT;
 
-        return $this->uri(new Uri($uri))($query);
+        return $this->uri(($this->uri)($uri))($query);
     }
 
     public function patch(string $uri, array $query = []) : ResourceObject
     {
         $this->method = Request::PATCH;
 
-        return $this->uri(new Uri($uri))($query);
+        return $this->uri(($this->uri)($uri))($query);
     }
 
     public function delete(string $uri, array $query = []) : ResourceObject
     {
         $this->method = Request::DELETE;
 
-        return $this->uri(new Uri($uri))($query);
+        return $this->uri(($this->uri)($uri))($query);
     }
 
     public function options(string $uri, array $query = []) : ResourceObject
     {
         $this->method = Request::OPTIONS;
 
-        return $this->uri(new Uri($uri))($query);
+        return $this->uri(($this->uri)($uri))($query);
     }
 
     public function head(string $uri, array $query = []) : ResourceObject
     {
         $this->method = Request::HEAD;
 
-        return $this->uri(new Uri($uri))($query);
+        return $this->uri(($this->uri)($uri))($query);
     }
 }

--- a/src/UriFactory.php
+++ b/src/UriFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource;
+
+use BEAR\Resource\Annotation\ContextSchema;
+use BEAR\Resource\Exception\UriException;
+use function parse_url;
+
+final class UriFactory
+{
+    /**
+     * @var string
+     */
+    private $schemaHost;
+
+    /**
+     * @ContextSchema
+     */
+    public function __construct(string $schemaHost = 'page://self')
+    {
+        $this->schemaHost = $schemaHost;
+    }
+
+    public function __invoke($uri, array $query = [])
+    {
+        if (array_keys(parse_url($uri)) === ['path']) {
+            $uri = $this->schemaHost . $uri;
+        }
+
+        return new Uri($uri, $query);
+    }
+
+    /**
+     * @throws UriException
+     */
+    private function validate(string $uri)
+    {
+        if (! filter_var($uri, FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED)) {
+            $msg = is_string($uri) ? $uri : gettype($uri);
+
+            throw new UriException($msg, 500);
+        }
+    }
+}

--- a/tests/LinkerTest.php
+++ b/tests/LinkerTest.php
@@ -42,7 +42,8 @@ class LinkerTest extends TestCase
         $this->linker = new Linker(
             new AnnotationReader,
             $this->invoker,
-            new Factory($schemeCollection)
+            new Factory($schemeCollection),
+            new UriFactory('app://self')
         );
     }
 

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -41,7 +41,8 @@ class ResourceTest extends TestCase
             ->scheme('nop')->host('self')->toAdapter(new FakeNop);
         $invoker = new Invoker(new NamedParameter(new NamedParamMetas(new ArrayCache, new AnnotationReader), new Injector), new OptionsRenderer(new OptionsMethods($reader)));
         $factory = new Factory($scheme);
-        $resource = new Resource($factory, $invoker, new Anchor($reader), new Linker($reader, $invoker, $factory));
+        $uri = new UriFactory('app://self');
+        $resource = new Resource($factory, $invoker, new Anchor($reader), new Linker($reader, $invoker, $factory, $uri), $uri);
         $this->assertInstanceOf(ResourceInterface::class, $resource);
     }
 


### PR DESCRIPTION
before

```php
$resource->get('app://self/'); // Valid
$resource->get('/'); // Invalid
```

after

```php
$resource->get('app://self/'); // Valid
$resource->get('/'); // Valid
```

The default schema can be changed as follows in the `cofigure()`  method.

```php
use BEAR\Resource\Annotation\ContextSchema
```
```php
class FooModule
{
    /**
     * {@inheritdoc}
     */
    protected function configure()
        // ...
        $this->bind()->annotatedWith(ContextSchema::class)->toInstance('app://self');
    } 
}
```
