### PR TITLE
Supports `http` resource

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -100,7 +100,7 @@ return \PhpCsFixer\Config::create()
         'no_unneeded_curly_braces' => true, // @Symfony
         'no_unneeded_final_method' => true, // @Symfony
         'no_unreachable_default_argument_value' => true,
-        'no_unset_on_property' => true,
+        'no_unset_on_property' => false,
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "koriym/http-constants": "^1.1",
         "ray/web-param-module": "^2.0",
         "justinrainbow/json-schema": "^5.2",
-        "phpdocumentor/reflection-docblock": "^4.3"
+        "phpdocumentor/reflection-docblock": "^4.3",
+        "symfony/http-client": "^4.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5",
@@ -54,7 +55,7 @@
     },
     "scripts" :{
         "test": ["phpunit"],
-        "tests": ["@cs", "phpstan analyse -l max src tests -c phpstan.neon --no-progress", "psalm --show-info=false", "@test"],
+        "tests": ["@cs", "phpstan analyse -l max src tests -c phpstan.neon --no-progress", "@test"],
         "coverage": ["php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-text --coverage-html=build/coverage"],
         "cs": ["php-cs-fixer fix -v --dry-run", "phpcs --standard=./phpcs.xml src"],
         "cs-fix": ["php-cs-fixer fix -v", "phpcbf src"]

--- a/src/HttpAdapter.php
+++ b/src/HttpAdapter.php
@@ -26,6 +26,8 @@ final class HttpAdapter implements AdapterInterface
      */
     public function get(AbstractUri $uri) : ResourceObject
     {
+        unset($uri);
+
         return $this->injector->getInstance(HttpResourceObject::class);
     }
 }

--- a/src/HttpAdapter.php
+++ b/src/HttpAdapter.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource;
+
+use Ray\Di\InjectorInterface;
+
+final class HttpAdapter implements AdapterInterface
+{
+    /**
+     * @var InjectorInterface
+     */
+    private $injector;
+
+    /**
+     * @param InjectorInterface $injector Application dependency injector
+     */
+    public function __construct(InjectorInterface $injector)
+    {
+        $this->injector = $injector;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get(AbstractUri $uri) : ResourceObject
+    {
+        return $this->injector->getInstance(HttpResourceObject::class);
+    }
+}

--- a/src/HttpResourceObject.php
+++ b/src/HttpResourceObject.php
@@ -35,18 +35,6 @@ final class HttpResourceObject extends ResourceObject
         unset($this->code, $this->headers, $this->body, $this->view);
     }
 
-    public function __call(string $name, array $arguments = ['get', []])
-    {
-        $method = strtoupper($name);
-        $params = isset($arguments[1]) ? $arguments[1] : [];
-        $options = ($method === 'GET') ? ['query' => $params] : ['body' => $params];
-        $clientOptions = isset($arguments['_options']) && is_array($arguments['_options']) ? $arguments['_options'] : [];
-        $options += $clientOptions;
-        $this->response = $this->client->request(strtoupper($name), $arguments[0], $options);
-
-        return $this;
-    }
-
     public function __get(string $name)
     {
         if ($name === 'code') {
@@ -78,5 +66,17 @@ final class HttpResourceObject extends ResourceObject
     public function __toString() : string
     {
         return $this->response->getContent();
+    }
+
+    public function request(AbstractRequest $request)
+    {
+        $uri = $request->resourceObject->uri;
+        $method = strtoupper($uri->method);
+        $options = ($method === 'GET') ? ['query' => $uri->query] : ['body' => $uri->query];
+        $clientOptions = isset($uri->query['_options']) && is_array($uri->query['_options']) ? $uri->query['_options'] : [];
+        $options += $clientOptions;
+        $this->response = $this->client->request($method, (string) $uri, $options);
+
+        return $this;
     }
 }

--- a/src/HttpResourceObject.php
+++ b/src/HttpResourceObject.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource;
+
+use function strtoupper;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @method HttpResourceObject get(AbstractUri|string $uri, array $params = [])
+ * @method HttpResourceObject head(AbstractUri|string $uri, array $params = [])
+ * @method HttpResourceObject put(AbstractUri|string $uri, array $params = [])
+ * @method HttpResourceObject post(AbstractUri|string $uri, array $params = [])
+ * @method HttpResourceObject patch(AbstractUri|string $uri, array $params = [])
+ * @method HttpResourceObject delete(AbstractUri|string $uri, array $params = [])
+ */
+final class HttpResourceObject extends ResourceObject
+{
+    /**
+     * @var HttpClientInterface
+     */
+    private $client;
+
+    /**
+     * @var ResponseInterface
+     */
+    private $response;
+
+    public function __construct(HttpClientInterface $client)
+    {
+        $this->client = $client;
+        unset($this->code, $this->headers, $this->body, $this->view);
+    }
+
+    public function __call(string $name, array $arguments = ['get', []])
+    {
+        $method = strtoupper($name);
+        $params = isset($arguments[1]) ? $arguments[1] : [];
+        $options = ($method === 'GET') ? ['query' => $params] : ['body' => $params];
+        $this->response = $this->client->request(strtoupper($name), $arguments[0], $options);
+
+        return $this;
+    }
+
+    public function __get(string $name)
+    {
+        if ($name === 'code') {
+            return $this->response->getStatusCode();
+        }
+        if ($name === 'headers') {
+            return $this->response->getHeaders();
+        }
+        if ($name === 'body') {
+            return $this->response->toArray();
+        }
+        if ($name === 'view') {
+            return $this->response->getContent();
+        }
+
+        throw new \InvalidArgumentException($name);
+    }
+
+    public function __set(string $name, $value) : void
+    {
+        $this->{$name} = $value;
+    }
+
+    public function __isset(string $name) : bool
+    {
+        return isset($this->{$name});
+    }
+
+    public function __toString() : string
+    {
+        return $this->response->getContent();
+    }
+}

--- a/src/HttpResourceObject.php
+++ b/src/HttpResourceObject.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BEAR\Resource;
 
+use function is_array;
 use function strtoupper;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -39,6 +40,8 @@ final class HttpResourceObject extends ResourceObject
         $method = strtoupper($name);
         $params = isset($arguments[1]) ? $arguments[1] : [];
         $options = ($method === 'GET') ? ['query' => $params] : ['body' => $params];
+        $clientOptions = isset($arguments['_options']) && is_array($arguments['_options']) ? $arguments['_options'] : [];
+        $options += $clientOptions;
         $this->response = $this->client->request(strtoupper($name), $arguments[0], $options);
 
         return $this;
@@ -64,7 +67,7 @@ final class HttpResourceObject extends ResourceObject
 
     public function __set(string $name, $value) : void
     {
-        $this->{$name} = $value;
+        throw new \InvalidArgumentException($name);
     }
 
     public function __isset(string $name) : bool

--- a/src/HttpResourceObject.php
+++ b/src/HttpResourceObject.php
@@ -55,6 +55,8 @@ final class HttpResourceObject extends ResourceObject
 
     public function __set(string $name, $value) : void
     {
+        unset($value);
+
         throw new \InvalidArgumentException($name);
     }
 

--- a/src/Invoker.php
+++ b/src/Invoker.php
@@ -35,6 +35,9 @@ final class Invoker implements InvokerInterface
      */
     public function invoke(AbstractRequest $request) : ResourceObject
     {
+        if ($request->resourceObject instanceof HttpResourceObject) {
+            return $request->resourceObject->request($request);
+        }
         $callable = [$request->resourceObject, 'on' . ucfirst($request->method)];
         if (! is_callable($callable)) {
             // OPTIONS or HEAD

--- a/src/Module/HttpClientModule.php
+++ b/src/Module/HttpClientModule.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\Module;
+
+use Ray\Di\AbstractModule;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class HttpClientModule extends AbstractModule
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->bind(HttpClientInterface::class)->toProvider(HttpClientProvider::class);
+    }
+}

--- a/src/Module/HttpClientProvider.php
+++ b/src/Module/HttpClientProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\Module;
+
+use Ray\Di\ProviderInterface;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class HttpClientProvider implements ProviderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function get() : HttpClientInterface
+    {
+        return HttpClient::create();
+    }
+}

--- a/src/Module/ResourceModule.php
+++ b/src/Module/ResourceModule.php
@@ -31,5 +31,6 @@ class ResourceModule extends AbstractModule
         $this->bind()->annotatedWith(AppName::class)->toInstance($this->appName);
         $this->install(new ResourceClientModule);
         $this->install(new EmbedResourceModule);
+        $this->install(new HttpClientModule);
     }
 }

--- a/src/Module/SchemeCollectionProvider.php
+++ b/src/Module/SchemeCollectionProvider.php
@@ -46,7 +46,7 @@ class SchemeCollectionProvider implements ProviderInterface
         $appAdapter = new AppAdapter($this->injector, $this->appName);
         $schemeCollection->scheme('page')->host('self')->toAdapter($pageAdapter);
         $schemeCollection->scheme('app')->host('self')->toAdapter($appAdapter);
-        $schemeCollection->scheme('http')->toAdapter(new HttpAdapter($this->injector));
+        $schemeCollection->scheme('http')->host('self')->toAdapter(new HttpAdapter($this->injector));
 
         return $schemeCollection;
     }

--- a/src/Module/SchemeCollectionProvider.php
+++ b/src/Module/SchemeCollectionProvider.php
@@ -6,6 +6,7 @@ namespace BEAR\Resource\Module;
 
 use BEAR\Resource\Annotation\AppName;
 use BEAR\Resource\AppAdapter;
+use BEAR\Resource\HttpAdapter;
 use BEAR\Resource\SchemeCollection;
 use Ray\Di\InjectorInterface;
 use Ray\Di\ProviderInterface;
@@ -45,6 +46,7 @@ class SchemeCollectionProvider implements ProviderInterface
         $appAdapter = new AppAdapter($this->injector, $this->appName);
         $schemeCollection->scheme('page')->host('self')->toAdapter($pageAdapter);
         $schemeCollection->scheme('app')->host('self')->toAdapter($appAdapter);
+        $schemeCollection->scheme('http')->toAdapter(new HttpAdapter($this->injector));
 
         return $schemeCollection;
     }

--- a/src/SchemeCollection.php
+++ b/src/SchemeCollection.php
@@ -66,6 +66,10 @@ final class SchemeCollection implements SchemeCollectionInterface
     {
         $schemeIndex = $uri->scheme . '://' . $uri->host;
         if (! array_key_exists($schemeIndex, $this->collection)) {
+            if ($uri->scheme === 'http') {
+                return  $this->collection['http://self'];
+            }
+
             throw new SchemeException($uri->scheme . '://' . $uri->host);
         }
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -6,6 +6,7 @@ namespace BEAR\Resource;
 
 use function array_key_exists;
 use BEAR\Resource\Exception\UriException;
+use function sprintf;
 
 final class Uri extends AbstractUri
 {
@@ -18,10 +19,11 @@ final class Uri extends AbstractUri
         if (count($query) !== 0) {
             $uri = uri_template($uri, $query);
         }
-        $parsedUrl = (array) parse_url($uri);
-        list($this->scheme, $this->host, $this->path) = array_values($parsedUrl);
-        if (array_key_exists('query', $parsedUrl)) {
-            parse_str($parsedUrl['query'], $this->query);
+        $parts = (array) parse_url($uri);
+        $host = isset($parts['port']) ? sprintf('%s:%s', $parts['host'], $parts['port']) : $parts['host'];
+        [$this->scheme, $this->host, $this->path] = [$parts['scheme'], $host, $parts['path']];
+        if (array_key_exists('query', $parts)) {
+            parse_str($parts['query'], $this->query);
         }
         if (count($query) !== 0) {
             $this->query = $query + $this->query;

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -20,8 +20,8 @@ final class Uri extends AbstractUri
             $uri = uri_template($uri, $query);
         }
         $parts = (array) parse_url($uri);
-        $host = isset($parts['port']) ? sprintf('%s:%s', $parts['host'], $parts['port']) : $parts['host'];
-        [$this->scheme, $this->host, $this->path] = [$parts['scheme'], $host, $parts['path']];
+        $host = isset($parts['port']) ? sprintf('%s:%s', $parts['host'] ?? null, $parts['port'] ?? null) : $parts['host'] ?? null;
+        [$this->scheme, $this->host, $this->path] = [$parts['scheme'] ?? null, $host, $parts['path'] ?? null];
         if (array_key_exists('query', $parts)) {
             parse_str($parts['query'], $this->query);
         }

--- a/tests/HttpResourceObjectTest.php
+++ b/tests/HttpResourceObjectTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\HttpClient;
+
+class HttpResourceObjectTest extends TestCase
+{
+    /**
+     * @var HttpResourceObject
+     */
+    private $ro;
+
+    protected function setUp() : void
+    {
+        $client = HttpClient::create();
+        $this->ro = new HttpResourceObject($client);
+    }
+
+    public function testGet()
+    {
+        $response = $this->ro->get('http://httpbin.org/get', ['foo' => 'bar']);
+        $this->assertSame(200, $response->code);
+        $this->assertArrayHasKey('access-control-allow-credentials', $response->headers);
+        $this->assertArrayHasKey('args', $response->body);
+        $this->assertContains('"args": {', $response->view);
+        $view = $response->view;
+    }
+
+    public function testPost()
+    {
+        $response = $this->ro->post('http://httpbin.org/post', ['foo' => 'bar']);
+        $this->assertSame(200, $response->code);
+        $this->assertArrayHasKey('access-control-allow-credentials', $response->headers);
+        $body = $response->body;
+        $this->assertSame('bar', $body['form']['foo']);
+        $this->assertContains('"form": {', $response->view);
+    }
+
+    public function testPut()
+    {
+        $response = $this->ro->put('http://httpbin.org/put', ['foo' => 'bar']);
+        $this->assertSame(200, $response->code);
+        $this->assertArrayHasKey('access-control-allow-credentials', $response->headers);
+        $body = $response->body;
+        $this->assertSame('bar', $body['form']['foo']);
+        $this->assertContains('"form": {', $response->view);
+    }
+
+    public function testPatch()
+    {
+        $response = $this->ro->patch('http://httpbin.org/patch', ['foo' => 'bar']);
+        $this->assertSame(200, $response->code);
+        $this->assertArrayHasKey('access-control-allow-credentials', $response->headers);
+        $body = $response->body;
+        $this->assertSame('bar', $body['form']['foo']);
+        $this->assertContains('"form": {', $response->view);
+    }
+
+    public function testDelete()
+    {
+        $response = $this->ro->delete('http://httpbin.org/delete', ['foo' => 'bar']);
+        $this->assertSame(200, $response->code);
+        $this->assertArrayHasKey('access-control-allow-credentials', $response->headers);
+        $body = $response->body;
+        $this->assertSame('bar', $body['form']['foo']);
+        $this->assertContains('"form": {', $response->view);
+    }
+}

--- a/tests/HttpResourceObjectTest.php
+++ b/tests/HttpResourceObjectTest.php
@@ -12,19 +12,12 @@ use Symfony\Component\HttpClient\HttpClient;
 class HttpResourceObjectTest extends TestCase
 {
     /**
-     * @var HttpResourceObject
-     */
-    private $ro;
-
-    /**
      * @var ResourceInterface
      */
     private $resource;
 
     protected function setUp() : void
     {
-        $client = HttpClient::create();
-        $this->ro = new HttpResourceObject($client);
         $injector = new Injector(new ResourceModule('FakeVendor\Sandbox'), __DIR__ . '/tmp');
         $this->resource = $injector->getInstance(ResourceInterface::class);
     }

--- a/tests/HttpResourceObjectTest.php
+++ b/tests/HttpResourceObjectTest.php
@@ -7,7 +7,6 @@ namespace BEAR\Resource;
 use BEAR\Resource\Module\ResourceModule;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
-use Symfony\Component\HttpClient\HttpClient;
 
 class HttpResourceObjectTest extends TestCase
 {

--- a/tests/HttpResourceObjectTest.php
+++ b/tests/HttpResourceObjectTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace BEAR\Resource;
 
+use BEAR\Resource\Module\ResourceModule;
 use PHPUnit\Framework\TestCase;
+use Ray\Di\Injector;
 use Symfony\Component\HttpClient\HttpClient;
 
 class HttpResourceObjectTest extends TestCase
@@ -14,25 +16,31 @@ class HttpResourceObjectTest extends TestCase
      */
     private $ro;
 
+    /**
+     * @var ResourceInterface
+     */
+    private $resource;
+
     protected function setUp() : void
     {
         $client = HttpClient::create();
         $this->ro = new HttpResourceObject($client);
+        $injector = new Injector(new ResourceModule('FakeVendor\Sandbox'), __DIR__ . '/tmp');
+        $this->resource = $injector->getInstance(ResourceInterface::class);
     }
 
     public function testGet()
     {
-        $response = $this->ro->get('http://httpbin.org/get', ['foo' => 'bar']);
+        $response = $this->resource->get('http://httpbin.org/get', ['foo' => 'bar']);
         $this->assertSame(200, $response->code);
         $this->assertArrayHasKey('access-control-allow-credentials', $response->headers);
         $this->assertArrayHasKey('args', $response->body);
         $this->assertContains('"args": {', $response->view);
-        $view = $response->view;
     }
 
     public function testPost()
     {
-        $response = $this->ro->post('http://httpbin.org/post', ['foo' => 'bar']);
+        $response = $this->resource->post('http://httpbin.org/post', ['foo' => 'bar']);
         $this->assertSame(200, $response->code);
         $this->assertArrayHasKey('access-control-allow-credentials', $response->headers);
         $body = $response->body;
@@ -42,7 +50,7 @@ class HttpResourceObjectTest extends TestCase
 
     public function testPut()
     {
-        $response = $this->ro->put('http://httpbin.org/put', ['foo' => 'bar']);
+        $response = $this->resource->put('http://httpbin.org/put', ['foo' => 'bar']);
         $this->assertSame(200, $response->code);
         $this->assertArrayHasKey('access-control-allow-credentials', $response->headers);
         $body = $response->body;
@@ -52,7 +60,7 @@ class HttpResourceObjectTest extends TestCase
 
     public function testPatch()
     {
-        $response = $this->ro->patch('http://httpbin.org/patch', ['foo' => 'bar']);
+        $response = $this->resource->patch('http://httpbin.org/patch', ['foo' => 'bar']);
         $this->assertSame(200, $response->code);
         $this->assertArrayHasKey('access-control-allow-credentials', $response->headers);
         $body = $response->body;
@@ -62,7 +70,7 @@ class HttpResourceObjectTest extends TestCase
 
     public function testDelete()
     {
-        $response = $this->ro->delete('http://httpbin.org/delete', ['foo' => 'bar']);
+        $response = $this->resource->delete('http://httpbin.org/delete', ['foo' => 'bar']);
         $this->assertSame(200, $response->code);
         $this->assertArrayHasKey('access-control-allow-credentials', $response->headers);
         $body = $response->body;


### PR DESCRIPTION
This PR supports `http` resource.

Schemas starting with `http(s)` will make an HTTP request, and the result will be treated the same as ResourceObject. `symfony/http-client` is used internally.

httpで始まるスキーマはhttpリクエストが行われ、結果はResourceObjectと同じように扱われます。

```php
$response = $this->resource->get('http://httpbin.org/get', ['foo' => 'bar']);
$this->assertSame(200, $response->code);
```

リクエストは非同期で行われます。
例えば以下の２つのリクエストは同時に実行され、値にアクセスした時点で同期されます。

Requests are made asynchronously.
For example, the following two requests execute simultaneously and are synchronized when accessing values:

```
$response1 = $this->resource->get('http://httpbin.org/get1', ['foo' => 'bar']); // 非同期 async
$response2 = $this->resource->get('http://httpbin.org/get2', ['foo' => 'bar']); // 非同期 async
$response1->body // 同期 sync
$response2->body // 同期 sync
```

phpunitのテストとHTTPリクエストを使ったインテグレーションテストのコードを共有することができます。