### PR TITLE
Capital camel case for HTTP header 'Content-Type'

### DIFF
--- a/src/HalRenderer.php
+++ b/src/HalRenderer.php
@@ -109,7 +109,7 @@ class HalRenderer implements RenderInterface
 
     private function updateHeaders(ResourceObject $ro) : void
     {
-        $ro->headers['content-type'] = 'application/hal+json';
+        $ro->headers['Content-Type'] = 'application/hal+json';
         if (isset($ro->headers['Location'])) {
             $ro->headers['Location'] = $this->link->getReverseLink($ro->headers['Location']);
         }

--- a/src/JsonRenderer.php
+++ b/src/JsonRenderer.php
@@ -11,8 +11,8 @@ final class JsonRenderer implements RenderInterface
      */
     public function render(ResourceObject $ro)
     {
-        if (! array_key_exists('content-type', $ro->headers)) {
-            $ro->headers['content-type'] = 'application/json';
+        if (! array_key_exists('Content-Type', $ro->headers)) {
+            $ro->headers['Content-Type'] = 'application/json';
         }
         $ro->view = (string) json_encode($ro);
         $e = json_last_error();

--- a/src/PrettyJsonRenderer.php
+++ b/src/PrettyJsonRenderer.php
@@ -11,8 +11,8 @@ final class PrettyJsonRenderer implements RenderInterface
      */
     public function render(ResourceObject $ro)
     {
-        if (! array_key_exists('content-type', $ro->headers)) {
-            $ro->headers['content-type'] = 'application/json';
+        if (! array_key_exists('Content-Type', $ro->headers)) {
+            $ro->headers['Content-Type'] = 'application/json';
         }
         $ro->view = json_encode($ro, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT) . PHP_EOL;
         $e = json_last_error();

--- a/tests/Renderer/HalRendererTest.php
+++ b/tests/Renderer/HalRendererTest.php
@@ -85,7 +85,7 @@ EOT;
         $ro = $this->ro->onGet();
         (string) $ro;
         $expected = 'application/hal+json';
-        $this->assertSame($expected, $ro->headers['content-type']);
+        $this->assertSame($expected, $ro->headers['Content-Type']);
     }
 
     public function testBodyLink()

--- a/tests/Renderer/JsonRendererTest.php
+++ b/tests/Renderer/JsonRendererTest.php
@@ -59,6 +59,6 @@ class JsonRendererTest extends TestCase
         $ro = $this->ro->onGet();
         (string) $ro;
         $expected = 'application/json';
-        $this->assertSame($expected, $ro->headers['content-type']);
+        $this->assertSame($expected, $ro->headers['Content-Type']);
     }
 }


### PR DESCRIPTION
It should be case insensitive, but some browser (IE) does not comply for it.

https://stackoverflow.com/questions/5258977/are-http-headers-case-sensitive/5259004