### PR TITLE
Avoid link if resource code >= BAD_REQUEST

### DIFF
--- a/src/Linker.php
+++ b/src/Linker.php
@@ -57,6 +57,10 @@ final class Linker implements LinkerInterface
     {
         $this->invoker->invoke($request);
         $current = clone $request->resourceObject;
+        if ($current->code >= Code::BAD_REQUEST) {
+            return $current;
+        }
+
         foreach ($request->links as $link) {
             /* @noinspection ExceptionsAnnotatingAndHandlingInspection */
             $nextResource = $this->annotationLink($link, $current, $request);

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/Blog/NotFound.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/Blog/NotFound.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the BEAR.Resource package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace FakeVendor\Sandbox\Resource\App\Blog;
+
+use BEAR\Resource\Annotation\Link;
+use BEAR\Resource\Code;
+use BEAR\Resource\ResourceObject;
+
+class NotFound extends ResourceObject
+{
+    /**
+     * @return $this
+     * @Link(href="app://self/user{?id}", rel="user", crawl="meta")
+     */
+    public function onGet()
+    {
+        $this->body = ['message' => 'blog not found'];
+        $this->code = Code::NOT_FOUND;
+
+        return $this;
+    }
+}

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/Blog/NotFound.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/Blog/NotFound.php
@@ -13,7 +13,6 @@ use BEAR\Resource\ResourceObject;
 class NotFound extends ResourceObject
 {
     /**
-     * @return $this
      * @Link(href="app://self/user{?id}", rel="user", crawl="meta")
      */
     public function onGet()

--- a/tests/LinkerTest.php
+++ b/tests/LinkerTest.php
@@ -303,4 +303,37 @@ class LinkerTest extends TestCase
         );
         $this->linker->invoke($request);
     }
+
+    public function testNotFoundResourceHasBody()
+    {
+        $request = new Request(
+            $this->invoker,
+            (new FakeRo)(new Blog\NotFound),
+            Request::GET,
+            [],
+            [new LinkType('meta', LinkType::CRAWL_LINK)]
+        );
+        $this->linker->invoke($request);
+        $this->assertSame(['message' => 'blog not found'], $request->body);
+
+        $request = new Request(
+            $this->invoker,
+            (new FakeRo)(new Blog\NotFound),
+            Request::GET,
+            [],
+            [new LinkType('user', LinkType::SELF_LINK)]
+        );
+        $this->linker->invoke($request);
+        $this->assertSame(['message' => 'blog not found'], $request->body);
+
+        $request = new Request(
+            $this->invoker,
+            (new FakeRo)(new Blog\NotFound),
+            Request::GET,
+            [],
+            [new LinkType('user', LinkType::NEW_LINK)]
+        );
+        $this->linker->invoke($request);
+        $this->assertSame(['message' => 'blog not found'], $request->body);
+    }
 }


### PR DESCRIPTION
Resourceのcodeがエラー系（ <= 400 ）の場合にのみLinkを実行するようにしました。
現状だとResource Bodyの内容で挙動が決定されており、例えばCodeがNOT_FOUNDでもBodyに値が入っているとLinkが実行されてしまいます。

`@Cacheable(expiryAt="xxx")` アノテーションでキャッシュの有効期限を設定している場合、左記アノテーションの `expiryAt` で使用する値をbodyに入れた状態で `code` に NOT_FOUND を設定すると発生しました。