### PR TITLE
Remove strict_types from Invoker

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -12,6 +12,7 @@ EOF;
 $finder = PhpCsFixer\Finder::create()
     ->exclude(['tests/Fake', 'tests/tmp', 'src-deprecated'])
     ->notPath('src/ClassParam.php')
+    ->notPath('src/Invoker.php')
     ->in(__DIR__);
 
 return \PhpCsFixer\Config::create()

--- a/src/EmbedInterceptor.php
+++ b/src/EmbedInterceptor.php
@@ -80,9 +80,7 @@ final class EmbedInterceptor implements MethodInterceptor
     }
 
     /**
-     * @return string[]
-     *
-     * @psalm-return array<string, string|object>
+     * @return array<string, mixed>
      */
     private function getArgsByInvocation(MethodInvocation $invocation) : array
     {

--- a/src/Invoker.php
+++ b/src/Invoker.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace BEAR\Resource;
 
 use function is_callable;


### PR DESCRIPTION
Disable strict type check with ResourceObject's parameters.

User ResourceObject class code can have `declare(strict_types=1)`.