### PR TITLE
Removing the return type void in php, which should be done in phpdoc for BC

### DIFF
--- a/src/ResourceObject.php
+++ b/src/ResourceObject.php
@@ -246,7 +246,7 @@ abstract class ResourceObject implements AcceptTransferInterface, ArrayAccess, C
     /**
      * {@inheritdoc}
      */
-    public function transfer(TransferInterface $responder, array $server) : void
+    public function transfer(TransferInterface $responder, array $server)
     {
         $responder($this, $server);
     }


### PR DESCRIPTION
`StreamTransferInject` を使った場合に、 `BEAR\Streamer\StreamTransferInject::transfer()` の型宣言と
不一致するため、Fatal error が起きる現象を修正しました。

`AcceptTransferInterface::transfer()` の phpdoc が `@return void` となっていて
`ResourceObject::transfer()` の phpdocは `{@inheritdoc}` なので、phpdoc は修正していません。