### PR TITLE
Remove strict_types=1 from ClassParam

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,16 +52,16 @@ jobs:
       php: 7.4
       install: composer global require --dev phpstan/phpstan ^0.12 vimeo/psalm ^3.11 phpmetrics/phpmetrics ^2.6
       script:
-        - ~/.composer/vendor/bin/phpstan analyse -c phpstan.neon --no-progress --no-interaction
-        - ~/.composer/vendor/bin/psalm --show-info=true --shepherd
-        - ~/.composer/vendor/bin/phpmetrics --exclude=Exception src
+        - composer global exec -v -- phpstan analyse -c phpstan.neon --no-progress --no-interaction
+        - composer global exec -v -- psalm --show-info=true --shepherd
+        - composer global exec -v -- phpmetrics --exclude=Exception src
 
     - stage: Code Quality
       name: Coding standards
       php: 7.4
       install: composer global require --dev doctrine/coding-standard ^8.1 maglnet/composer-require-checker ^2.0
       script:
-        - ~/.composer/vendor/bin/phpcs --standard=./phpcs.xml src tests
-        - ~/.composer/vendor/bin/composer-require-checker check ./composer.json
+        - composer global exec -v -- phpcs --standard=./phpcs.xml src tests
+        - composer global exec -v -- composer-require-checker check ./composer.json
   allow_failures:
     - php: nightly

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -65,7 +65,7 @@
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing">
-        <exclude-pattern>*/ClassParam.php</exclude-pattern>
+        <exclude-pattern>src/ClassParam.php</exclude-pattern>
     </rule>
     <exclude-pattern>*/Fake/*</exclude-pattern>
     <exclude-pattern>*/tmp/*</exclude-pattern>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -64,6 +64,9 @@
             <property name="maxLinesCountBeforeWithoutComment" value="0"/>
         </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing">
+        <exclude-pattern>*/ClassParam.php</exclude-pattern>
+    </rule>
     <exclude-pattern>*/Fake/*</exclude-pattern>
     <exclude-pattern>*/tmp/*</exclude-pattern>
 </ruleset>

--- a/src/ClassParam.php
+++ b/src/ClassParam.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace BEAR\Resource;
 
 use BEAR\Resource\Exception\ParameterException;

--- a/src/OptionsMethods.php
+++ b/src/OptionsMethods.php
@@ -67,7 +67,7 @@ final class OptionsMethods
         $methodOption = $doc;
         $paramMetas = (new OptionsMethodRequest($this->reader))($method, $paramDoc, $ins);
         $schema = $this->getJsonSchema($method);
-        $request = $paramMetas ? ['request' => $paramMetas] : []; // @phpstan-ignore-line
+        $request = $paramMetas ? ['request' => $paramMetas] : [];
         $methodOption += $request;
         if (! empty($schema)) {
             $methodOption += ['schema' => $schema];


### PR DESCRIPTION
Webからの入力の場合は全て文字列なので `stric_types=1` だとClassParamが動かないため外しました。