### PR TITLE
Update fzaninotto/faker version constrain for PHP8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "justinrainbow/json-schema": "^5.2",
         "koriym/http-constants": "^1.1",
         "koriym/json-schema-faker": "^0.1.2",
-        "fzaninotto/faker": "^1.9",
+        "fzaninotto/faker": "1.9.x-dev",
         "nocarrier/hal": "^0.9.12",
         "phpdocumentor/reflection-docblock": "^5.2",
         "psr/log": "^1.1",


### PR DESCRIPTION
`1.9.x-dev` is compatible with PHP8.

fzaninotto/Faker is archived. 
https://marmelab.com/blog/2020/10/21/sunsetting-faker.html

A stable version with php8 can't be expected.