### PR TITLE
Clone URI

### DIFF
--- a/src/ResourceObject.php
+++ b/src/ResourceObject.php
@@ -293,4 +293,9 @@ abstract class ResourceObject implements AcceptTransferInterface, ArrayAccess, C
 
         return $body;
     }
+
+    public function __clone()
+    {
+        $this->uri = clone $this->uri;
+    }
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -150,9 +150,11 @@ class RequestTest extends TestCase
             ['a' => 'koriym', 'b' => 25]
         );
         $no = $str = '';
-        set_error_handler(static function (int $errno, string $errstr) use (&$no, &$str) {
+        set_error_handler(static function (int $errno, string $errstr) use (&$no, &$str): bool {
             $no = $errno;
             $str = $errstr;
+
+            return true;
         });
         (string) $request; // @phpstan-ignore-line
         $this->assertSame(E_USER_WARNING, $no);
@@ -262,9 +264,11 @@ class RequestTest extends TestCase
             ['key' => 'animal', 'value' => 'kuma']
         );
         $no = $str = '';
-        set_error_handler(static function (int $errno, string $errstr) use (&$no, &$str) {
+        set_error_handler(static function (int $errno, string $errstr) use (&$no, &$str): bool {
             $no = $errno;
             $str = $errstr;
+
+            return true;
         });
         (string) $request; // @phpstan-ignore-line
         $this->assertSame(256, $no);

--- a/tests/ResourceObjectTest.php
+++ b/tests/ResourceObjectTest.php
@@ -98,4 +98,15 @@ class ResourceObjectTest extends TestCase
         $ro->body = '1';
         $ro['key']; // @phpstan-ignore-line
     }
+
+    public function testClone(): void
+    {
+        $ro = new FakeResource();
+        $ro->uri = new Uri('app://self/?modified=0');
+        $this->assertSame(['modified' => '0'], $ro->uri->query);
+        $clonedRo = clone $ro;
+        // change cloned uri
+        $clonedRo->uri->query = ['modified' => '1'];
+        $this->assertSame(['modified' => '0'], $ro->uri->query);
+    }
 }


### PR DESCRIPTION
Since PHP defaults to a shallow copy, the cloned ResourceObject points to the same URI, but this should be a different URI.