### PR TITLE
Give default values for attributes

### DIFF
--- a/src/Annotation/AppName.php
+++ b/src/Annotation/AppName.php
@@ -20,7 +20,7 @@ final class AppName
     /** @var string */
     public $value;
 
-    public function __construct(string $value)
+    public function __construct(string $value = '')
     {
         $this->value = $value;
     }

--- a/src/Annotation/ImportAppConfig.php
+++ b/src/Annotation/ImportAppConfig.php
@@ -20,7 +20,7 @@ final class ImportAppConfig
     /** @var string */
     public $value;
 
-    public function __construct(string $value)
+    public function __construct(string $value = '')
     {
         $this->value = $value;
     }

--- a/src/Annotation/OptionsBody.php
+++ b/src/Annotation/OptionsBody.php
@@ -20,7 +20,7 @@ final class OptionsBody
     /** @var string */
     public $value;
 
-    public function __construct(string $value)
+    public function __construct(string $value = '')
     {
         $this->value = $value;
     }

--- a/src/AppAdapter.php
+++ b/src/AppAdapter.php
@@ -50,7 +50,7 @@ final class AppAdapter implements AdapterInterface
         /** @var ''|class-string $class */
         $class = sprintf('%s\Resource\%s', $this->namespace, str_replace('/', '\\', ucwords($uri->scheme) . $path));
         try {
-            $instance = $this->injector->getInstance($class); // @phpstan-ignore-line
+            $instance = $this->injector->getInstance($class);
             assert($instance instanceof ResourceObject);
         } catch (Unbound $e) {
             throw $this->getNotFound($uri, $e, $class);

--- a/tests/Module/JsonSchemaLinkHeaderModuleTest.php
+++ b/tests/Module/JsonSchemaLinkHeaderModuleTest.php
@@ -14,7 +14,7 @@ class JsonSchemaLinkHeaderModuleTest extends TestCase
     {
         $jsonSchemaHost = 'http://example.com/schema/';
         $injector = new Injector(new JsonSchemaLinkHeaderModule($jsonSchemaHost));
-        $instance = $injector->getInstance('', 'json_schema_host'); // @phpstan-ignore-line
+        $instance = $injector->getInstance('', 'json_schema_host');
         $this->assertSame($jsonSchemaHost, $instance);
     }
 


### PR DESCRIPTION
メソッドではなく、パラメーターに直接Qualifierを指定するときは変数名が必要なく、そのために[アトリビュートの生成](https://github.com/koriym/Koriym.Attributes/blob/7be4ab979b535b246d95267e48d4b24a9f52fca0/src/AttributeReader.php#L45)でエラーになってしまうことを防ぎます。

つまりクオリファイアー（識別子=named）のアトリビュートがアノテーションと互換性を持たせるためにコンスタラクタを持っている場合は、いずれもデフォルトの値が必要です。互換性を捨ててアトリビュートにすることが可能な場合には(PHP8以上）コンストラクタそのものを取り除くようにします。