### PR TITLE
Add ResourceObjectModule

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,9 +7,8 @@ on:
 
 jobs:
   ci:
-    uses: ray-di/.github/.github/workflows/continuous-integration.yml@next_stable
+    uses: ray-di/.github/.github/workflows/continuous-integration.yml@v1
     with:
-      old_stable: '["8.0"]'
-      current_stable: 8.1
-      next_stable: 8.2
+      old_stable: '["8.0", "8.1"]'
+      current_stable: 8.2
       script: demo/run.php

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "squizlabs/php_codesniffer": "^3.5",
         "vimeo/psalm": "^4.17",
         "ray/rector-ray": "^1.0",
-        "rector/rector": "^0.14.8"
+        "rector/rector": "^0.14.8",
+        "ray/compiler": "^1.9.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Module/ResourceObjectModule.php
+++ b/src/Module/ResourceObjectModule.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\Module;
+
+use BEAR\Resource\ResourceObject;
+use Ray\Di\AbstractModule;
+
+/**
+ * Bind resource object for compile
+ */
+class ResourceObjectModule extends AbstractModule
+{
+    /** @param iterable<class-string<ResourceObject>> $resourceObjects */
+    public function __construct(
+        private iterable $resourceObjects,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        foreach ($this->resourceObjects as $ro) {
+            $this->bind($ro);
+        }
+    }
+}

--- a/tests/Fake/FakeLazyModule.php
+++ b/tests/Fake/FakeLazyModule.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource;
+
+use Ray\Compiler\LazyModuleInterface;
+use Ray\Di\AbstractModule;
+
+final class FakeLazyModule implements LazyModuleInterface
+{
+    public function __construct(private AbstractModule $module)
+    {
+    }
+
+    public function __invoke(): AbstractModule
+    {
+        return $this->module;
+    }
+}

--- a/tests/Module/ResrouceObjectModuleTest.php
+++ b/tests/Module/ResrouceObjectModuleTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\Module;
+
+use BEAR\Resource\FakeLazyModule;
+use BEAR\Resource\ResourceObject;
+use FakeVendor\Sandbox\Resource\Page\HelloWorld;
+use FakeVendor\Sandbox\Resource\Page\Index;
+use Generator;
+use PHPUnit\Framework\TestCase;
+use Ray\Compiler\CompileInjector;
+
+final class ResrouceObjectModuleTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        array_map('unlink', (array) glob(__DIR__ . '/tmp/{*.php}', GLOB_BRACE));
+    }
+
+    public function testConfigureWithGenerator(): void
+    {
+        $injector = new CompileInjector(
+            __DIR__ . '/tmp',
+            new FakeLazyModule(new ResourceObjectModule($this->getResourceObjectGenerator())),
+        );
+
+        $this->assertInstanceOf(Index::class, $injector->getInstance(Index::class));
+        $this->assertInstanceOf(HelloWorld::class, $injector->getInstance(HelloWorld::class));
+    }
+
+    public function testConfigureWithArray(): void
+    {
+        $injector = new CompileInjector(
+            __DIR__ . '/tmp',
+            new FakeLazyModule(new ResourceObjectModule(iterator_to_array($this->getResourceObjectGenerator()))),
+        );
+
+        $this->assertInstanceOf(Index::class, $injector->getInstance(Index::class));
+        $this->assertInstanceOf(HelloWorld::class, $injector->getInstance(HelloWorld::class));
+    }
+
+    /** @return Generator<class-string<ResourceObject>> */
+    private function getResourceObjectGenerator(): Generator
+    {
+        yield Index::class;
+        yield HelloWorld::class;
+    }
+}

--- a/tests/Module/ResrouceObjectModuleTest.php
+++ b/tests/Module/ResrouceObjectModuleTest.php
@@ -12,13 +12,19 @@ use Generator;
 use PHPUnit\Framework\TestCase;
 use Ray\Compiler\CompileInjector;
 
+use function array_map;
+use function glob;
+use function iterator_to_array;
+
+use const GLOB_BRACE;
+
 final class ResrouceObjectModuleTest extends TestCase
 {
     protected function setUp(): void
     {
         parent::setUp();
 
-        array_map('unlink', (array) glob(__DIR__ . '/tmp/{*.php}', GLOB_BRACE));
+        array_map('unlink', (array) glob(__DIR__ . '/tmp/{*.php}', GLOB_BRACE)); // @phpstan-ignore-line
     }
 
     public function testConfigureWithGenerator(): void


### PR DESCRIPTION
https://github.com/bearsunday/BEAR.Package/blob/1.x/src/Module/ResourceObjectModule.php のように CompileInjector のために ResourceObject を束縛するためのモジュールを実装しました。

BEAR.Package の ResourceObjectModule とはコンストラクタで受け取る値の型を変えています。