### PR TITLE
Preparation to avoid max_input_vars error

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -8,5 +8,6 @@ on:
 jobs:
   sa:
     uses: ray-di/.github/.github/workflows/static-analysis.yml@v1
+    has_crc_config: true
     with:
       php_version: 8.2

--- a/php-require-checker.config.json
+++ b/php-require-checker.config.json
@@ -3,6 +3,7 @@
     "null", "true", "false",
     "static", "self", "parent",
     "array", "string", "int", "float", "bool", "iterable", "callable", "void", "object",
-    "Attribute", "ReflectionAttribute", "Stringable"
+    "Attribute", "ReflectionAttribute", "Stringable",
+    "BEAR\\Resource\\HalLink", "BEAR\\Resource\\NullReverseLink", "BEAR\\Resource\\ReverseLinkInterface"
   ]
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,5 +7,6 @@ parameters:
     - '%currentWorkingDirectory%/tests/tmp/*'
     - '%currentWorkingDirectory%/tests/Module/tmp/*'
     - '%currentWorkingDirectory%/tests/Fake/*'
+    - tests/HttpResourceObjectTest.php
   ignoreErrors:
   		- '#Access to an undefined property#'

--- a/src-deprecated/HalLink.php
+++ b/src-deprecated/HalLink.php
@@ -10,6 +10,7 @@ use Nocarrier\Hal;
 use function is_string;
 use function uri_template;
 
+/** @deprecated  Use HalLinker instead */
 final class HalLink
 {
     public function __construct(

--- a/src-deprecated/NullReverseLink.php
+++ b/src-deprecated/NullReverseLink.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BEAR\Resource;
 
+/** @deprecated  Use NullReverseLinker instead */
 final class NullReverseLink implements ReverseLinkInterface
 {
     public function __invoke(string $uri): string

--- a/src-deprecated/ReverseLinkInterface.php
+++ b/src-deprecated/ReverseLinkInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BEAR\Resource;
 
+/** @deprecated  */
 interface ReverseLinkInterface
 {
     /**

--- a/src/HalLinker.php
+++ b/src/HalLinker.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource;
+
+use BEAR\Resource\Annotation\Link;
+use Nocarrier\Hal;
+
+use function is_string;
+use function uri_template;
+
+final class HalLinker
+{
+    public function __construct(
+        private ReverseLinkerInterface $link,
+    ) {
+    }
+
+    public function getReverseLink(string $uri, array $query): string
+    {
+        return ($this->link)($uri, $query);
+    }
+
+    /**
+     * @param array<mixed> $body
+     * @param list<object> $methodAnnotations
+     */
+    public function addHalLink(array $body, array $methodAnnotations, Hal $hal): Hal
+    {
+        if (! empty($methodAnnotations)) {
+            $hal = $this->linkAnnotation($body, $methodAnnotations, $hal);
+        }
+
+        if (isset($body['_links'])) {
+            /** @var array{_links: array<string, array{href: string}>} $body */
+            $hal = $this->bodyLink($body, $hal);
+        }
+
+        return $hal;
+    }
+
+    /**
+     * @param array<int|string, mixed>|array{_links: string} $body
+     * @param Link                                           $methodAnnotations
+     */
+    private function linkAnnotation(array $body, array $methodAnnotations, Hal $hal): Hal
+    {
+        foreach ($methodAnnotations as $annotation) {
+            if (! $annotation instanceof Link) {
+                continue;
+            }
+
+            $uri = uri_template($annotation->href, $body);
+            $reverseUri = $this->getReverseLink($uri, []);
+
+            if (isset($body['_links'][$annotation->rel])) { // @phpstan-ignore-line
+                // skip if already difined links in ResourceObject
+                continue;
+            }
+
+            $hal->addLink($annotation->rel, $reverseUri);
+        }
+
+        return $hal;
+    }
+
+    /**
+     * @param array{_links: array<array{href?: string}>} $body
+     *
+     * User can set `_links` array as a `Links` annotation
+     */
+    private function bodyLink(array $body, Hal $hal): Hal
+    {
+        foreach ($body['_links'] as $rel => $link) {
+            if (! is_string($rel) || ! isset($link['href'])) {
+                continue;
+            }
+
+            $attr = $link;
+            unset($attr['href']);
+            $hal->addLink($rel, $link['href'], $attr);
+        }
+
+        return $hal;
+    }
+}

--- a/src/HalLinker.php
+++ b/src/HalLinker.php
@@ -17,6 +17,7 @@ final class HalLinker
     ) {
     }
 
+    /** @param array<string, mixed> $query */
     public function getReverseLink(string $uri, array $query): string
     {
         return ($this->link)($uri, $query);
@@ -42,7 +43,7 @@ final class HalLinker
 
     /**
      * @param array<int|string, mixed>|array{_links: string} $body
-     * @param Link                                           $methodAnnotations
+     * @param non-empty-list<object>                         $methodAnnotations
      */
     private function linkAnnotation(array $body, array $methodAnnotations, Hal $hal): Hal
     {

--- a/src/HalLinker.php
+++ b/src/HalLinker.php
@@ -75,7 +75,9 @@ final class HalLinker
     {
         foreach ($body['_links'] as $rel => $link) {
             if (! is_string($rel) || ! isset($link['href'])) {
+                // @codeCoverageIgnoreStart
                 continue;
+                // @codeCoverageIgnoreEnd
             }
 
             $attr = $link;

--- a/src/HalRenderer.php
+++ b/src/HalRenderer.php
@@ -17,10 +17,13 @@ use function is_scalar;
 use function is_string;
 use function json_decode;
 use function method_exists;
+use function parse_str;
+use function parse_url;
 use function ucfirst;
 
 use const JSON_THROW_ON_ERROR;
 use const PHP_EOL;
+use const PHP_URL_QUERY;
 
 final class HalRenderer implements RenderInterface
 {
@@ -140,6 +143,12 @@ final class HalRenderer implements RenderInterface
             return;
         }
 
-        $ro->headers['Location'] = $this->linker->getReverseLink($ro->headers['Location'], $ro->uri->query);
+        $url = parse_url($ro->headers['Location'], PHP_URL_QUERY);
+        $isRelativePath = $url === null;
+        $path = $isRelativePath ? $ro->headers['Location'] : $url;
+        parse_str((string) $path, $query);
+        /** @var array<string, string> $query */
+
+        $ro->headers['Location'] = $this->linker->getReverseLink($ro->headers['Location'], $query);
     }
 }

--- a/src/HalRenderer.php
+++ b/src/HalRenderer.php
@@ -26,7 +26,7 @@ final class HalRenderer implements RenderInterface
 {
     public function __construct(
         private Reader $reader,
-        private HalLink $link,
+        private HalLinker $linker,
     ) {
     }
 
@@ -105,10 +105,10 @@ final class HalRenderer implements RenderInterface
     {
         $query = $uri->query ? '?' . http_build_query($uri->query) : '';
         $path = $uri->path . $query;
-        $selfLink = $this->link->getReverseLink($path);
+        $selfLink = $this->linker->getReverseLink($path, $uri->query);
         $hal = new Hal($selfLink, $body);
 
-        return $this->link->addHalLink($body, $annotations, $hal);
+        return $this->linker->addHalLink($body, $annotations, $hal);
     }
 
     /** @return array{0: ResourceObject, 1: array<array-key, mixed>} */
@@ -140,6 +140,6 @@ final class HalRenderer implements RenderInterface
             return;
         }
 
-        $ro->headers['Location'] = $this->link->getReverseLink($ro->headers['Location']);
+        $ro->headers['Location'] = $this->linker->getReverseLink($ro->headers['Location'], $ro->uri->query);
     }
 }

--- a/src/HttpAdapter.php
+++ b/src/HttpAdapter.php
@@ -15,6 +15,8 @@ final class HttpAdapter implements AdapterInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
      */
     public function get(AbstractUri $uri): ResourceObject
     {

--- a/src/HttpAdapter.php
+++ b/src/HttpAdapter.php
@@ -15,8 +15,6 @@ final class HttpAdapter implements AdapterInterface
 
     /**
      * {@inheritDoc}
-     *
-     * @codeCoverageIgnore
      */
     public function get(AbstractUri $uri): ResourceObject
     {

--- a/src/Module/ResourceClientModule.php
+++ b/src/Module/ResourceClientModule.php
@@ -86,10 +86,16 @@ final class ResourceClientModule extends AbstractModule
         $this->bind(OptionsMethods::class);
         $this->bind(NamedParamMetasInterface::class)->to(NamedParamMetas::class);
         $this->bind(ExtraMethodInvoker::class);
-        $this->bind(HalLink::class);
-        $this->bind(ReverseLinkInterface::class)->to(NullReverseLink::class);
         $this->bind(HalLinker::class);
         $this->bind(ReverseLinkerInterface::class)->to(NullReverseLinker::class);
         $this->bind(LoggerInterface::class)->to(NullLogger::class);
+        $this->configureDeprecatedBindings();
+    }
+
+    /** @psalm-suppress DeprecatedClass */
+    private function configureDeprecatedBindings(): void
+    {
+        $this->bind(HalLink::class); // @phpstan-ignore
+        $this->bind(ReverseLinkInterface::class)->to(NullReverseLink::class); // @phpstan-ignore
     }
 }

--- a/src/Module/ResourceClientModule.php
+++ b/src/Module/ResourceClientModule.php
@@ -10,6 +10,7 @@ use BEAR\Resource\ExtraMethodInvoker;
 use BEAR\Resource\Factory;
 use BEAR\Resource\FactoryInterface;
 use BEAR\Resource\HalLink;
+use BEAR\Resource\HalLinker;
 use BEAR\Resource\Invoker;
 use BEAR\Resource\InvokerInterface;
 use BEAR\Resource\Linker;
@@ -21,12 +22,14 @@ use BEAR\Resource\NamedParamMetas;
 use BEAR\Resource\NamedParamMetasInterface;
 use BEAR\Resource\NullLogger;
 use BEAR\Resource\NullReverseLink;
+use BEAR\Resource\NullReverseLinker;
 use BEAR\Resource\OptionsMethods;
 use BEAR\Resource\OptionsRenderer;
 use BEAR\Resource\PrettyJsonRenderer;
 use BEAR\Resource\RenderInterface;
 use BEAR\Resource\Resource;
 use BEAR\Resource\ResourceInterface;
+use BEAR\Resource\ReverseLinkerInterface;
 use BEAR\Resource\ReverseLinkInterface;
 use BEAR\Resource\SchemeCollectionInterface;
 use BEAR\Resource\UriFactory;
@@ -55,6 +58,8 @@ use Ray\Di\Scope;
  * HalLink
  * ReverseLinkInterface
  * LoggerInterface
+ * HalLinker
+ * ReverseLinkerInterface
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
@@ -83,6 +88,8 @@ final class ResourceClientModule extends AbstractModule
         $this->bind(ExtraMethodInvoker::class);
         $this->bind(HalLink::class);
         $this->bind(ReverseLinkInterface::class)->to(NullReverseLink::class);
+        $this->bind(HalLinker::class);
+        $this->bind(ReverseLinkerInterface::class)->to(NullReverseLinker::class);
         $this->bind(LoggerInterface::class)->to(NullLogger::class);
     }
 }

--- a/src/NullReverseLinker.php
+++ b/src/NullReverseLinker.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource;
+
+final class NullReverseLinker implements ReverseLinkerInterface
+{
+    public function __invoke(string $uri, array $query): string
+    {
+        return $uri;
+    }
+}

--- a/src/NullReverseLinker.php
+++ b/src/NullReverseLinker.php
@@ -6,6 +6,7 @@ namespace BEAR\Resource;
 
 final class NullReverseLinker implements ReverseLinkerInterface
 {
+    /** @param array<string, mixed> $query */
     public function __invoke(string $uri, array $query): string
     {
         return $uri;

--- a/src/ReverseLinkerInterface.php
+++ b/src/ReverseLinkerInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource;
+
+interface ReverseLinkerInterface
+{
+    /**
+     * Return reverse URI
+     */
+    public function __invoke(string $uri, array $query): string;
+}

--- a/src/ReverseLinkerInterface.php
+++ b/src/ReverseLinkerInterface.php
@@ -7,6 +7,7 @@ namespace BEAR\Resource;
 interface ReverseLinkerInterface
 {
     /**
+     * @param array<string, mixed> $query
      * Return reverse URI
      */
     public function __invoke(string $uri, array $query): string;

--- a/tests/Fake/FakeReverseLinker.php
+++ b/tests/Fake/FakeReverseLinker.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace BEAR\Resource;
+
+final class FakeReverseLinker implements ReverseLinkerInterface
+{
+    public function __invoke(string $uri, array $query): string
+    {
+        return "/user/{$query['id']}";
+    }
+}

--- a/tests/FakeNullRo.php
+++ b/tests/FakeNullRo.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource;
+
+final class FakeNullRo extends ResourceObject
+{
+    public function onGet(): static
+    {
+        return $this;
+    }
+}

--- a/tests/HalLinkerTest.php
+++ b/tests/HalLinkerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BEAR\Resource;
 
+use Doctrine\Common\Annotations\AnnotationReader;
 use Nocarrier\Hal;
 use PHPUnit\Framework\TestCase;
 
@@ -19,5 +20,16 @@ class HalLinkerTest extends TestCase
         ];
         $hal = $halLink->addHalLink($body, [], new Hal());
         $this->assertInstanceOf(Hal::class, $hal);
+    }
+
+    public function testHalLinker(): void
+    {
+        $halRenderer = new HalRenderer(new AnnotationReader(), new HalLinker(new FakeReverseLinker()));
+        $fakeRo = new FakeNullRo();
+        $fakeRo->uri = new Uri('app://self/?id=10');
+        $fakeRo->setRenderer($halRenderer);
+        $fakeRo->headers = ['Location' => 'http://example.com/go?id=10'];
+        (string) $fakeRo;
+        $this->assertSame('/user/10', $fakeRo->headers['Location']);
     }
 }

--- a/tests/HalLinkerTest.php
+++ b/tests/HalLinkerTest.php
@@ -8,12 +8,12 @@ use Nocarrier\Hal;
 use PHPUnit\Framework\TestCase;
 
 /** @deprecated */
-class HalLinkTest extends TestCase
+class HalLinkerTest extends TestCase
 {
     /** @covers \BEAR\Resource\HalLink::bodyLink() */
     public function testBodyLinkInvalidLink(): void
     {
-        $halLink = new HalLink(new NullReverseLink());
+        $halLink = new HalLinker(new NullReverseLinker());
         $body = [
             '_links' => ['rel1' => 'not-href'],
         ];

--- a/tests/HttpResourceObjectTest.php
+++ b/tests/HttpResourceObjectTest.php
@@ -25,7 +25,6 @@ class HttpResourceObjectTest extends TestCase
 
     public function testGet(): HttpResourceObject
     {
-        $this->markTestSkipped();
         $response = $this->resource->get('http://httpbin.org/get', ['foo' => 'bar']);
         $this->assertSame(200, $response->code);
         $this->assertArrayHasKey('Access-control-allow-credentials', $response->headers);
@@ -39,7 +38,6 @@ class HttpResourceObjectTest extends TestCase
 
     public function testPost(): void
     {
-        $this->markTestSkipped();
         $response = $this->resource->post('http://httpbin.org/post', ['foo' => 'bar']);
         $this->assertSame(200, $response->code);
         $this->assertArrayHasKey('Access-control-allow-credentials', $response->headers);
@@ -50,7 +48,6 @@ class HttpResourceObjectTest extends TestCase
 
     public function testPut(): void
     {
-        $this->markTestSkipped();
         $response = $this->resource->put('http://httpbin.org/put', ['foo' => 'bar']);
         $this->assertSame(200, $response->code);
         $this->assertArrayHasKey('Access-control-allow-credentials', $response->headers);
@@ -61,7 +58,6 @@ class HttpResourceObjectTest extends TestCase
 
     public function testPatch(): void
     {
-        $this->markTestSkipped();
         $response = $this->resource->patch('http://httpbin.org/patch', ['foo' => 'bar']);
         $this->assertSame(200, $response->code);
         $this->assertArrayHasKey('Access-control-allow-credentials', $response->headers);
@@ -72,7 +68,6 @@ class HttpResourceObjectTest extends TestCase
 
     public function testDelete(): void
     {
-        $this->markTestSkipped();
         $response = $this->resource->delete('http://httpbin.org/delete', ['foo' => 'bar']);
         $this->assertSame(200, $response->code);
         $this->assertArrayHasKey('Access-control-allow-credentials', $response->headers);

--- a/tests/HttpResourceObjectTest.php
+++ b/tests/HttpResourceObjectTest.php
@@ -25,6 +25,7 @@ class HttpResourceObjectTest extends TestCase
 
     public function testGet(): HttpResourceObject
     {
+        $this->markTestSkipped();
         $response = $this->resource->get('http://httpbin.org/get', ['foo' => 'bar']);
         $this->assertSame(200, $response->code);
         $this->assertArrayHasKey('Access-control-allow-credentials', $response->headers);
@@ -38,6 +39,7 @@ class HttpResourceObjectTest extends TestCase
 
     public function testPost(): void
     {
+        $this->markTestSkipped();
         $response = $this->resource->post('http://httpbin.org/post', ['foo' => 'bar']);
         $this->assertSame(200, $response->code);
         $this->assertArrayHasKey('Access-control-allow-credentials', $response->headers);
@@ -48,6 +50,7 @@ class HttpResourceObjectTest extends TestCase
 
     public function testPut(): void
     {
+        $this->markTestSkipped();
         $response = $this->resource->put('http://httpbin.org/put', ['foo' => 'bar']);
         $this->assertSame(200, $response->code);
         $this->assertArrayHasKey('Access-control-allow-credentials', $response->headers);
@@ -58,6 +61,7 @@ class HttpResourceObjectTest extends TestCase
 
     public function testPatch(): void
     {
+        $this->markTestSkipped();
         $response = $this->resource->patch('http://httpbin.org/patch', ['foo' => 'bar']);
         $this->assertSame(200, $response->code);
         $this->assertArrayHasKey('Access-control-allow-credentials', $response->headers);
@@ -68,6 +72,7 @@ class HttpResourceObjectTest extends TestCase
 
     public function testDelete(): void
     {
+        $this->markTestSkipped();
         $response = $this->resource->delete('http://httpbin.org/delete', ['foo' => 'bar']);
         $this->assertSame(200, $response->code);
         $this->assertArrayHasKey('Access-control-allow-credentials', $response->headers);

--- a/tests/Renderer/HalRendererTest.php
+++ b/tests/Renderer/HalRendererTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace BEAR\Resource\Renderer;
 
 use BEAR\Resource\FakeHal;
-use BEAR\Resource\HalLink;
+use BEAR\Resource\HalLinker;
 use BEAR\Resource\HalRenderer;
-use BEAR\Resource\NullReverseLink;
+use BEAR\Resource\NullReverseLinker;
 use BEAR\Resource\Uri;
 use PHPUnit\Framework\TestCase;
 use Ray\ServiceLocator\ServiceLocator;
@@ -20,7 +20,7 @@ class HalRendererTest extends TestCase
     {
         $this->ro = new FakeHal();
         $this->ro->uri = new Uri('app://self/dummy');
-        $this->ro->setRenderer(new HalRenderer(ServiceLocator::getReader(), new HalLink(new NullReverseLink())));
+        $this->ro->setRenderer(new HalRenderer(ServiceLocator::getReader(), new HalLinker(new NullReverseLinker())));
     }
 
     public function testRender(): void


### PR DESCRIPTION
* HalLink => HalLinker
* ReverseLinkInterface => ReverseLinkerInterface
* NullReverseLink => NullReverseLinker
* ReverseLinkInterface => ReverseLinkerInterface

`HalLink::getReverseLink()`では、これまで連想配列のWeb入力（$queryからクエリー形式の$uri文字列になったものを再度、配列に戻していました。しかしそれでは巨大な$query配列の場合、再度戻す時に` Input variables exceeded `のPHPエラーが発生してしまいます。

このエラーはiniファイルのmax_input_varsディレクティブの値を超す数のクエリーをパースする際に発生します。

この問題を避けるために、クエリー形式文字列をパースするのではなく、クエリーを配列のまま渡すようにします。

このPRはbear/packageのReverseLinkerInterface実装で効果を表します。エラーはbear/packageで発生しますが、bear/resourceの今回のPRでクエリー配列を渡す修正が必要です。

https://www.php.net/manual/ja/function.parse-str.php

Related: https://github.com/bearsunday/BEAR.Package/pull/420