### PR TITLE
Support BackedEnum param

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,5 +8,6 @@ parameters:
     - '%currentWorkingDirectory%/tests/Module/tmp/*'
     - '%currentWorkingDirectory%/tests/Fake/*'
     - tests/HttpResourceObjectTest.php
+    - tests/HalLinkerTest.php
   ignoreErrors:
   		- '#Access to an undefined property#'

--- a/src/ClassParam.php
+++ b/src/ClassParam.php
@@ -14,6 +14,7 @@ use function assert;
 use function class_exists;
 use function enum_exists;
 use function is_a;
+use function is_iterable;
 use function ltrim;
 use function preg_replace;
 use function strtolower;
@@ -43,6 +44,7 @@ final class ClassParam implements ParamInterface
     public function __invoke(string $varName, array $query, InjectorInterface $injector)
     {
         try {
+            /** @psalm-suppress MixedAssignment */
             $props = $this->getProps($varName, $query, $injector);
         } catch (ParameterException $e) {
             if ($this->isDefaultAvailable) {
@@ -57,6 +59,8 @@ final class ClassParam implements ParamInterface
         if ($refClass->isEnum()) {
             return $this->enum($this->type, $props);
         }
+
+        assert(is_iterable($props));
 
         $hasConstructor = (bool) $refClass->getConstructor();
         if ($hasConstructor) {
@@ -92,7 +96,8 @@ final class ClassParam implements ParamInterface
         throw new ParameterException($varName);
     }
 
-    private function enum(string $type, mixed $props)
+    /** @psalm-suppress MixedArgument */
+    private function enum(string $type, mixed $props): mixed
     {
         $refEnum = new ReflectionEnum($type);
         assert(enum_exists($type));
@@ -103,6 +108,6 @@ final class ClassParam implements ParamInterface
 
         assert(is_a($type, BackedEnum::class, true));
 
-        return $type::from($props);
+        return $type::from($props); // @phpstan-ignore-line
     }
 }

--- a/src/ClassParam.php
+++ b/src/ClassParam.php
@@ -65,12 +65,8 @@ final class ClassParam implements ParamInterface
         return $obj;
     }
 
-    /**
-     * @param array<string, array<string, mixed>> $query
-     *
-     * @return array<string, mixed>
-     */
-    private function getProps(string $varName, array $query, InjectorInterface $injector): array
+    /** @param array<string, mixed> $query */
+    private function getProps(string $varName, array $query, InjectorInterface $injector): mixed
     {
         if (isset($query[$varName])) {
             return $query[$varName];

--- a/src/ClassParam.php
+++ b/src/ClassParam.php
@@ -19,6 +19,8 @@ use function ltrim;
 use function preg_replace;
 use function strtolower;
 
+use const PHP_VERSION_ID;
+
 final class ClassParam implements ParamInterface
 {
     private string $type;
@@ -56,7 +58,8 @@ final class ClassParam implements ParamInterface
 
         assert(class_exists($this->type));
         $refClass = (new ReflectionClass($this->type));
-        if ($refClass->isEnum()) {
+
+        if (PHP_VERSION_ID >= 80100 && $refClass->isEnum()) {
             return $this->enum($this->type, $props);
         }
 

--- a/src/NamedParameter.php
+++ b/src/NamedParameter.php
@@ -23,7 +23,7 @@ final class NamedParameter implements NamedParameterInterface
         $parameters = [];
         foreach ($metas as $varName => $param) {
             /** @psalm-suppress all */
-            $parameters[] = $param($varName, $query, $this->injector); // @phpstan-ignore-line
+            $parameters[] = $param($varName, $query, $this->injector);
         }
 
         return $parameters;

--- a/src/NotBackedEnumException.php
+++ b/src/NotBackedEnumException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource;
+
+use LogicException;
+
+class NotBackedEnumException extends LogicException
+{
+}

--- a/src/ParamInterface.php
+++ b/src/ParamInterface.php
@@ -9,7 +9,7 @@ use Ray\Di\InjectorInterface;
 interface ParamInterface
 {
     /**
-     * @param array<string, array<string, mixed>> $query
+     * @param array<string, mixed> $query
      *
      * @return mixed
      */

--- a/tests/Fake/FakeIntBacked.php
+++ b/tests/Fake/FakeIntBacked.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource;
+
+enum FakeIntBacked: int
+{
+    case FOO = 1;
+    case BAR = 2;
+}

--- a/tests/Fake/FakeNotBacked.php
+++ b/tests/Fake/FakeNotBacked.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource;
+
+enum FakeNotBacked
+{
+    case FOO;
+    case BAR;
+}

--- a/tests/Fake/FakeStringBacked.php
+++ b/tests/Fake/FakeStringBacked.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource;
+
+enum FakeStringBacked: string
+{
+    case FOO = 'foo';
+    case BAR = 'bar';
+}

--- a/tests/Fake/FakeVendor/Sandbox/Resource/Page/EnumParam.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/Page/EnumParam.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BEAR\Resource\FakeVendor\Sandbox\Resource\Page;
 
 use BEAR\Resource\FakeIntBacked;
+use BEAR\Resource\FakeNotBacked;
 use BEAR\Resource\FakeStringBacked;
 use BEAR\Resource\ResourceObject;
 
@@ -14,6 +15,12 @@ final class EnumParam extends ResourceObject
         FakeStringBacked $stringBacked,
         FakeIntBacked $intBacked,
         FakeStringBacked|null $hasDefault = null,
+    ): static {
+        return $this;
+    }
+
+    public function onPut(
+        FakeNotBacked $notBacked,
     ): static {
         return $this;
     }

--- a/tests/Fake/FakeVendor/Sandbox/Resource/Page/EnumParam.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/Page/EnumParam.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\FakeVendor\Sandbox\Resource\Page;
+
+use BEAR\Resource\FakeIntBacked;
+use BEAR\Resource\FakeStringBacked;
+use BEAR\Resource\ResourceObject;
+
+final class EnumParam extends ResourceObject
+{
+    public function onGet(
+        FakeStringBacked $stringBacked,
+        FakeIntBacked $intBacked,
+        FakeStringBacked|null $hasDefault = null,
+    ): static {
+        return $this;
+    }
+}

--- a/tests/NamedParameterTest.php
+++ b/tests/NamedParameterTest.php
@@ -117,4 +117,15 @@ class NamedParameterTest extends TestCase
 
         $this->assertSame([FakeStringBacked::FOO, FakeIntBacked::FOO, null], $args);
     }
+
+    public function testNotBackedEnumParam(): void
+    {
+        $this->expectException(NotBackedEnumException::class);
+
+        $ro = new FakeVendor\Sandbox\Resource\Page\EnumParam();
+
+        $params = ['notBacked' => 'foo'];
+
+        $this->params->getParameters([$ro, 'onPut'], $params);
+    }
 }

--- a/tests/NamedParameterTest.php
+++ b/tests/NamedParameterTest.php
@@ -108,6 +108,7 @@ class NamedParameterTest extends TestCase
         $this->assertSame(['userId' => 'koriym', 'userRole' => 'lead'], (array) $ro->body);
     }
 
+    /** @requires PHP >= 8.1 */
     public function testEnumParam(): void
     {
         $ro = new FakeVendor\Sandbox\Resource\Page\EnumParam();
@@ -118,6 +119,7 @@ class NamedParameterTest extends TestCase
         $this->assertSame([FakeStringBacked::FOO, FakeIntBacked::FOO, null], $args);
     }
 
+    /** @requires PHP >= 8.1 */
     public function testNotBackedEnumParam(): void
     {
         $this->expectException(NotBackedEnumException::class);

--- a/tests/NamedParameterTest.php
+++ b/tests/NamedParameterTest.php
@@ -107,4 +107,14 @@ class NamedParameterTest extends TestCase
         assert($ro instanceof ResourceObject);
         $this->assertSame(['userId' => 'koriym', 'userRole' => 'lead'], (array) $ro->body);
     }
+
+    public function testEnumParam(): void
+    {
+        $ro = new FakeVendor\Sandbox\Resource\Page\EnumParam();
+
+        $params = ['stringBacked' => 'foo', 'intBacked' => '1'];
+        $args = $this->params->getParameters([$ro, 'onGet'], $params);
+
+        $this->assertSame([FakeStringBacked::FOO, FakeIntBacked::FOO, null], $args);
+    }
 }


### PR DESCRIPTION
# 概要

ResourceObject のパラメータに BackedEnum を利用できるようにしました。

# 変更点

主な変更点は以下のとおりです。

* src/ParamInterface.php の $query の期待する型を変更
* ClassParam で Enum を取り扱えるように

## src/ParamInterface.php の $query の期待する型を変更

もともと`array<string, array<string, mixed>>` となっていますが、 RequiredParam などには `array<string, mixed>` がパスされるケースもあることから後者に変更しました。

## ClassParam で Enum を取り扱えるように

EnumParam のようなクラスを実装することも検討しましたが、Enumかを判別するには ReflectionClass::isEnum を呼び出す必要があり、ClassParamで処理するのが妥当そうであったのでそのままにしています。

# その他気になる点

BackedEnum は int と string しかサポートしていないため、パラメータの検証などが必要になりますが、そこまで厳密にはおこなっていません。
ClassParam全体でもう少し値の検証をちゃんとやったほうが良いのかなという印象はあります。
