### PR TITLE
Enum exceptions in more detail

### DIFF
--- a/src/Exception/ParameterEnumTypeException.php
+++ b/src/Exception/ParameterEnumTypeException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\Exception;
+
+class ParameterEnumTypeException extends ParameterException
+{
+}

--- a/src/Exception/ParameterInvalidEnumException.php
+++ b/src/Exception/ParameterInvalidEnumException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\Exception;
+
+class ParameterInvalidEnumException extends ParameterException
+{
+}

--- a/tests/Fake/FakeVendor/Sandbox/Resource/Page/EnumParam.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/Page/EnumParam.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace BEAR\Resource\FakeVendor\Sandbox\Resource\Page;
+namespace FakeVendor\Sandbox\Resource\Page;
 
 use BEAR\Resource\FakeIntBacked;
 use BEAR\Resource\FakeNotBacked;
@@ -16,6 +16,11 @@ final class EnumParam extends ResourceObject
         FakeIntBacked $intBacked,
         FakeStringBacked|null $hasDefault = null,
     ): static {
+        $this->body = [
+            'stringBacked' => $stringBacked->value,
+            'intBacked' => $intBacked->value
+        ];
+
         return $this;
     }
 


### PR DESCRIPTION
In the Enum parameter...

* Incorrect type specification other than int or string raises `ParameterEnumTypeException`
* Not enumerated raises `ParameterInvalidEnumException`

Each exception class inherits from ParameterException. That allows it to be a bad request exception.

Related:
https://github.com/bearsunday/bearsunday.github.io/pull/245