### PR TITLE
Update CI v2

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -7,6 +7,4 @@ on:
 
 jobs:
   cs:
-    uses: ray-di/.github/.github/workflows/coding-standards.yml@v1
-    with:
-      php_version: 8.1
+    uses: ray-di/.github/.github/workflows/coding-standards.yml@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,8 +7,6 @@ on:
 
 jobs:
   ci:
-    uses: ray-di/.github/.github/workflows/continuous-integration.yml@v1
+    uses: ray-di/.github/.github/workflows/continuous-integration.yml@v2
     with:
-      old_stable: '["8.0", "8.1", "8.2"]'
-      current_stable: 8.3
       script: demo/run.php

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,7 +7,5 @@ on:
 
 jobs:
   sa:
-    uses: ray-di/.github/.github/workflows/static-analysis.yml@v1
+    uses: ray-di/.github/.github/workflows/static-analysis.yml@v2
     has_crc_config: true
-    with:
-      php_version: 8.2


### PR DESCRIPTION
ray-di/.github v2 will be compatible with the latest PHP support version.