### PR TITLE
Validation only when body content is present

### DIFF
--- a/src/JsonSchema/Interceptor/JsonSchemaInterceptor.php
+++ b/src/JsonSchema/Interceptor/JsonSchemaInterceptor.php
@@ -60,7 +60,7 @@ final class JsonSchemaInterceptor implements JsonSchemaInterceptorInterface
 
         $ro = $invocation->proceed();
         assert($ro instanceof ResourceObject);
-        if ($ro->body && $ro->code === 200 || $ro->code === 201) {
+        if ($ro->body !== [] &&  $ro->code === 200 || $ro->code === 201) {
             $this->validateResponse($ro, $jsonSchema);
         }
 

--- a/src/JsonSchema/Interceptor/JsonSchemaInterceptor.php
+++ b/src/JsonSchema/Interceptor/JsonSchemaInterceptor.php
@@ -60,7 +60,7 @@ final class JsonSchemaInterceptor implements JsonSchemaInterceptorInterface
 
         $ro = $invocation->proceed();
         assert($ro instanceof ResourceObject);
-        if ($ro->code === 200 || $ro->code === 201) {
+        if ($ro->body && $ro->code === 200 || $ro->code === 201) {
             $this->validateResponse($ro, $jsonSchema);
         }
 

--- a/src/JsonSchema/Interceptor/JsonSchemaInterceptor.php
+++ b/src/JsonSchema/Interceptor/JsonSchemaInterceptor.php
@@ -60,7 +60,7 @@ final class JsonSchemaInterceptor implements JsonSchemaInterceptorInterface
 
         $ro = $invocation->proceed();
         assert($ro instanceof ResourceObject);
-        if ($ro->body !== [] &&  $ro->code === 200 || $ro->code === 201) {
+        if ($ro->body !== [] && $ro->code === 200 || $ro->code === 201) {
             $this->validateResponse($ro, $jsonSchema);
         }
 


### PR DESCRIPTION
bodyの値が`[]`の時にJsonSchemaによるチェックを行わない。

`/item?id=100`として該当のアイテムがなければ`[]`が変えるがJsonSchemaを使って空配列を許容するのはOneOfを使う必要があり煩雑になるため。

代替案としてはJsonSchemaアトリビュートに空配列を許すようなパラメータの導入。例えば`allow_empty:null`など。