### PR TITLE
Invoke request interface

### DIFF
--- a/src/ClassParam.php
+++ b/src/ClassParam.php
@@ -11,6 +11,7 @@ use ReflectionClass;
 use ReflectionEnum;
 use ReflectionNamedType;
 use ReflectionParameter;
+use UnitEnum;
 
 use function assert;
 use function class_exists;
@@ -103,9 +104,14 @@ final class ClassParam implements ParamInterface
         throw new ParameterException($varName);
     }
 
-    /** @psalm-suppress MixedArgument */
+    /**
+     * @param class-string $type
+     *
+     * @psalm-suppress MixedArgument
+     */
     private function enum(string $type, mixed $props, string $varName): mixed
     {
+        /** @var class-string<UnitEnum> $type */
         $refEnum = new ReflectionEnum($type);
         assert(enum_exists($type));
 

--- a/src/HalLinker.php
+++ b/src/HalLinker.php
@@ -55,7 +55,7 @@ final class HalLinker
             $uri = uri_template($annotation->href, $body);
             $reverseUri = $this->getReverseLink($uri, []);
 
-            if (isset($body['_links'][$annotation->rel])) { // @phpstan-ignore-line
+            if (isset($body['_links'][$annotation->rel])) {
                 // skip if already difined links in ResourceObject
                 continue;
             }

--- a/src/HttpResourceObject.php
+++ b/src/HttpResourceObject.php
@@ -105,6 +105,12 @@ final class HttpResourceObject extends ResourceObject implements InvokeRequestIn
     public function _invokeRequest(InvokerInterface $invoker, AbstractRequest $request): ResourceObject
     {
         unset($invoker);
+
+        return $this->request($request);
+    }
+
+    public function request(AbstractRequest $request): self
+    {
         $uri = $request->resourceObject->uri;
         $method = strtoupper($uri->method);
         $options = $method === 'GET' ? ['query' => $uri->query] : ['body' => $uri->query];

--- a/src/HttpResourceObject.php
+++ b/src/HttpResourceObject.php
@@ -26,7 +26,7 @@ use function ucwords;
  * @property-read array<string, string> $body
  * @property-read string                $view
  */
-final class HttpResourceObject extends ResourceObject
+final class HttpResourceObject extends ResourceObject implements InvokeRequestInterface
 {
     /** {@inheritDoc} */
     public $body;
@@ -102,8 +102,9 @@ final class HttpResourceObject extends ResourceObject
         return $this->response->getContent();
     }
 
-    public function request(AbstractRequest $request): self
+    public function _invokeRequest(InvokerInterface $invoker, AbstractRequest $request): ResourceObject
     {
+        unset($invoker);
         $uri = $request->resourceObject->uri;
         $method = strtoupper($uri->method);
         $options = $method === 'GET' ? ['query' => $uri->query] : ['body' => $uri->query];

--- a/src/InvokeRequestInterface.php
+++ b/src/InvokeRequestInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource;
+
+interface InvokeRequestInterface
+{
+    /**
+     * Invokes a request using the given invoker and request objects.
+     *
+     * @return ResourceObject The resulting resource object returned from the request invocation.
+     */
+    public function _invokeRequest(InvokerInterface $invoker, AbstractRequest $request): ResourceObject;
+}

--- a/src/Invoker.php
+++ b/src/Invoker.php
@@ -3,18 +3,10 @@
 
 namespace BEAR\Resource;
 
-use BEAR\Resource\Exception\BadRequestException;
-use Throwable;
-use function call_user_func_array;
-use function is_callable;
-use function ucfirst;
-
 final class Invoker implements InvokerInterface
 {
     public function __construct(
-        private NamedParameterInterface $params,
-        private ExtraMethodInvoker $extraMethod,
-        private LoggerInterface $logger,
+        private PhpClassInvoker $classInvoker
     ) {
     }
 
@@ -26,30 +18,6 @@ final class Invoker implements InvokerInterface
         if ($request->resourceObject instanceof HttpResourceObject) {
             return $request->resourceObject->request($request);
         }
-
-        $callable = [$request->resourceObject, 'on' . ucfirst($request->method)];
-        if (! is_callable($callable)) {
-            // OPTIONS or HEAD
-            return ($this->extraMethod)($request, $this);
-        }
-
-        $params = $this->params->getParameters($callable, $request->query);
-        /** @psalm-suppress MixedAssignment */
-        try {
-            $response = call_user_func_array($callable, $params);
-        } catch (Throwable $e) {
-            if ($e::class === \TypeError::class) {
-                throw new BadRequestException('Invalid parameter type', Code::BAD_REQUEST, $e);
-            }
-            throw $e;
-        }
-        if (! $response instanceof ResourceObject) {
-            $request->resourceObject->body = $response;
-            $response = $request->resourceObject;
-        }
-
-        ($this->logger)($response);
-
-        return $response;
+        return $this->classInvoker->invoke($request);
     }
 }

--- a/src/Invoker.php
+++ b/src/Invoker.php
@@ -15,9 +15,6 @@ final class Invoker implements InvokerInterface
      */
     public function invoke(AbstractRequest $request): ResourceObject
     {
-        if ($request->resourceObject instanceof HttpResourceObject) {
-            return $request->resourceObject->request($request);
-        }
-        return $this->classInvoker->invoke($request);
+        return $request->resourceObject->_invokeRequest($this->classInvoker, $request);
     }
 }

--- a/src/Module/ResourceClientModule.php
+++ b/src/Module/ResourceClientModule.php
@@ -25,6 +25,7 @@ use BEAR\Resource\NullReverseLink;
 use BEAR\Resource\NullReverseLinker;
 use BEAR\Resource\OptionsMethods;
 use BEAR\Resource\OptionsRenderer;
+use BEAR\Resource\PhpClassInvoker;
 use BEAR\Resource\PrettyJsonRenderer;
 use BEAR\Resource\RenderInterface;
 use BEAR\Resource\Resource;
@@ -90,6 +91,7 @@ final class ResourceClientModule extends AbstractModule
         $this->bind(ReverseLinkerInterface::class)->to(NullReverseLinker::class);
         $this->bind(LoggerInterface::class)->to(NullLogger::class);
         $this->configureDeprecatedBindings();
+        $this->bind(PhpClassInvoker::class);
     }
 
     /** @psalm-suppress DeprecatedClass */

--- a/src/PhpClassInvoker.php
+++ b/src/PhpClassInvoker.php
@@ -1,0 +1,51 @@
+<?php
+// phpcs:ignoreFile
+
+namespace BEAR\Resource;
+
+use BEAR\Resource\Exception\BadRequestException;
+use Throwable;
+use function call_user_func_array;
+use function is_callable;
+use function ucfirst;
+
+final class PhpClassInvoker implements InvokerInterface
+{
+    public function __construct(
+        private NamedParameterInterface $params,
+        private ExtraMethodInvoker $extraMethod,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function invoke(AbstractRequest $request): ResourceObject
+    {
+        $callable = [$request->resourceObject, 'on' . ucfirst($request->method)];
+        if (! is_callable($callable)) {
+            // OPTIONS or HEAD
+            return ($this->extraMethod)($request, $this);
+        }
+
+        $params = $this->params->getParameters($callable, $request->query);
+        /** @psalm-suppress MixedAssignment */
+        try {
+            $response = call_user_func_array($callable, $params);
+        } catch (Throwable $e) {
+            if ($e::class === \TypeError::class) {
+                throw new BadRequestException('Invalid parameter type', Code::BAD_REQUEST, $e);
+            }
+            throw $e;
+        }
+        if (! $response instanceof ResourceObject) {
+            $request->resourceObject->body = $response;
+            $response = $request->resourceObject;
+        }
+
+        ($this->logger)($response);
+
+        return $response;
+    }
+}

--- a/src/ResourceObject.php
+++ b/src/ResourceObject.php
@@ -32,7 +32,7 @@ use const E_USER_WARNING;
  * @phpstan-implements ArrayAccess<string, mixed>
  * @phpstan-implements IteratorAggregate<(int|string), mixed>
  */
-abstract class ResourceObject implements AcceptTransferInterface, ArrayAccess, Countable, IteratorAggregate, JsonSerializable, Stringable
+abstract class ResourceObject implements AcceptTransferInterface, ArrayAccess, Countable, IteratorAggregate, JsonSerializable, Stringable, InvokeRequestInterface
 {
     /**
      * @var AbstractUri
@@ -260,5 +260,21 @@ abstract class ResourceObject implements AcceptTransferInterface, ArrayAccess, C
     public function __clone()
     {
         $this->uri = clone $this->uri;
+    }
+
+    /**
+     * Invokes a request using the specified invoker and request object.
+     *
+     * Requests from resource clients are called and executed by this method. Unconventionally,
+     * underscores are added to method names to avoid conflicts with method names in classes that inherit from existing ResouceObjects.
+     *
+     * @param InvokerInterface $invoker The invoker to use for invoking the request.
+     * @param AbstractRequest  $request The request object to be invoked.
+     *
+     * @return ResourceObject The result of invoking the request.
+     */
+    public function _invokeRequest(InvokerInterface $invoker, AbstractRequest $request): ResourceObject
+    {
+        return $invoker->invoke($request);
     }
 }

--- a/tests/InvokerFactory.php
+++ b/tests/InvokerFactory.php
@@ -11,18 +11,20 @@ final class InvokerFactory
     public function __invoke(string $schemaDir = ''): Invoker
     {
         return new Invoker(
-            new NamedParameter(
-                new NamedParamMetas(),
-                new Injector(),
-            ),
-            new ExtraMethodInvoker(
-                new OptionsRenderer(
-                    new OptionsMethods(
-                        $schemaDir,
+            new PhpClassInvoker(
+                new NamedParameter(
+                    new NamedParamMetas(),
+                    new Injector(),
+                ),
+                new ExtraMethodInvoker(
+                    new OptionsRenderer(
+                        new OptionsMethods(
+                            $schemaDir,
+                        ),
                     ),
                 ),
+                new NullLogger(),
             ),
-            new NullLogger(),
         );
     }
 }


### PR DESCRIPTION
ResourceObjects that are called to execute resources (calls to onGet methods, etc.), which were done by Invoker, will be passed Invoker to do so. This is the same as the current Transfer mechanism and enhances object autonomy in object-oriented programming.

The benefits gained are

The if statement that used to determine whether an object was an HTTP request object (HttpResourceObject) or a PHP ResourceObject on the Invoker side is eliminated, and resources other than HTTP and PHP method calls can be handled. You can open extensions and close changes for new resources like [BEAR.Thrift](https://github.com/bearsunday/BEAR.Thrift).

Other extras.

1) You can also write the processing before and after the execution of an object on the ResourceObject side, like AOP.
2) You can also replace it with your own Invoker.

Invokerが行っていたリソースの実行（onGetメソッドなどの呼び出し）を呼ばれたResourceObjectがInvokerを渡してもらって、実行するようにします。現在のTransferの仕組みと同じでオブジェクト指向においてのオブジェクトの自律を強化します。

得られるメリットは

従来Invoker側でHTTPリクエストオブジェクト（HttpResourceObject）なのか、PHPのResourceObjectなのかを判断していたif文を取り除き、HTTPやPHPのメソッドコール以外のリソースも対応できます。[BEAR.Thrift](https://github.com/bearsunday/BEAR.Thrift)のような新しいリソースに対して拡張を開き、変更を閉じることができます。

他におまけで

1) AOPのようにオブジェクトの実行の前後の処理をResourceObject側に記述することもできる。
2) 自身のInvokerに差し替えることもできる
