### PR TITLE
Self link

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -45,6 +45,7 @@
         <exclude name="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.MissingVariable"/>
         <exclude name="SlevomatCodingStandard.Commenting.UselessInheritDocComment.UselessInheritDocComment"/>
         <exclude name="Squiz.Commenting.FunctionComment.InvalidNoReturn"/>
+        <exclude name="PSR2.Methods.MethodDeclaration.Underscore"/>
         <!-- /Base -->
         <!-- Option -->
 <!--        <exclude name="SlevomatCodingStandard.ControlStructures.EarlyExit.EarlyExitNotUsed"/>-->

--- a/src/EmbedInterceptor.php
+++ b/src/EmbedInterceptor.php
@@ -18,6 +18,8 @@ use function uri_template;
 
 final class EmbedInterceptor implements MethodInterceptor
 {
+    private const SELF_LINK = '_self';
+
     private readonly ResourceInterface $resource;
 
     public function __construct(
@@ -71,6 +73,12 @@ final class EmbedInterceptor implements MethodInterceptor
                     throw new LinkException($embed->rel); // @codeCoverageIgnore
                 }
 
+                if ($embed->rel === self::SELF_LINK) {
+                    $this->linkSelf($request, $ro);
+
+                    continue;
+                }
+
                 $ro->body[$embed->rel] = clone $request;
             } catch (BadRequestException $e) {
                 // wrap ResourceNotFound or Uri exception
@@ -100,5 +108,13 @@ final class EmbedInterceptor implements MethodInterceptor
         }
 
         return $namedParameters;
+    }
+
+    public function linkSelf(Request $request, ResourceObject $ro): void
+    {
+        $result = $request();
+        foreach ($result as $key => $value) {
+            $ro->body[$key] = $value;
+        }
     }
 }

--- a/src/EmbedInterceptor.php
+++ b/src/EmbedInterceptor.php
@@ -14,6 +14,7 @@ use Ray\Aop\MethodInvocation;
 use function array_shift;
 use function assert;
 use function is_array;
+use function is_string;
 use function uri_template;
 
 final class EmbedInterceptor implements MethodInterceptor
@@ -113,8 +114,14 @@ final class EmbedInterceptor implements MethodInterceptor
     public function linkSelf(Request $request, ResourceObject $ro): void
     {
         $result = $request();
-        foreach ($result as $key => $value) {
-            $ro->body[$key] = $value;
+        assert(is_array($result->body));
+        /** @var mixed $value */
+        foreach ($result->body as $key => $value) {
+            assert(is_string($key));
+            /** @psalm-suppress MixedArrayAssignment */
+            $ro->body[$key] = $value; // @phpstan-ignore-line
         }
+
+        $ro->code = $result->code;
     }
 }

--- a/tests/EmbedInterceptorTest.php
+++ b/tests/EmbedInterceptorTest.php
@@ -37,6 +37,13 @@ class EmbedInterceptorTest extends TestCase
         return $result;
     }
 
+    public function testSelfLink(): void
+    {
+        $embeded = $this->resource->uri('app://self/bird/child')(['id' => 1]);
+        $result = $this->resource->uri('app://self/bird/self-link')(['id' => 1]);
+        $this->assertSame($result->body, $embeded->body);
+    }
+
     public function testInvokeRelativePath(): BirdsRel
     {
         $result = $this->resource->uri('app://self/bird/birds-rel')(['id' => 1]);

--- a/tests/EmbedInterceptorTest.php
+++ b/tests/EmbedInterceptorTest.php
@@ -42,6 +42,7 @@ class EmbedInterceptorTest extends TestCase
         $embeded = $this->resource->uri('app://self/bird/child')(['id' => 1]);
         $result = $this->resource->uri('app://self/bird/self-link')(['id' => 1]);
         $this->assertSame($result->body, $embeded->body);
+        $this->assertSame($result->code, $embeded->code);
     }
 
     public function testInvokeRelativePath(): BirdsRel

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/Bird/Child.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/Bird/Child.php
@@ -8,6 +8,8 @@ use BEAR\Resource\ResourceObject;
 
 class Child extends ResourceObject
 {
+    public $code = 100;
+
     public function onGet(string $id)
     {
         $this->body = [

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/Bird/Child.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/Bird/Child.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FakeVendor\Sandbox\Resource\App\Bird;
+
+use BEAR\Resource\ResourceObject;
+
+class Child extends ResourceObject
+{
+    public function onGet(string $id)
+    {
+        $this->body = [
+            'id' => $id
+        ];
+
+        return $this;
+    }
+}

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/Bird/SelfLink.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/Bird/SelfLink.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FakeVendor\Sandbox\Resource\App\Bird;
+
+use BEAR\Resource\Annotation\Embed;
+use BEAR\Resource\Annotation\Link;
+use BEAR\Resource\ResourceObject;
+
+class SelfLink extends ResourceObject
+{
+    #[Embed(rel: "_self", src: "app://self/bird/child{?id}")]
+    public function onGet(string $id)
+    {
+        return $this;
+    }
+}


### PR DESCRIPTION
## 通常時

通常 

`#[Embed(rel: "foo", src: "app://self/bar")]`


のアトリビュートだと`$this->body['foo']` に `app://self/bar`Requestオブジェクトがアサインされます。


## 提案

それに対して`rel`で自己リンク`_self`を指定すると

`#[Embed(rel: "_self", src: "app://self/bar")]`

自身のリソースのbodyが`src`で指定したリソースになります。通常の場合と違ってリクエストオブジェクトではなく、即実行されてその結果が代入されます。

## ユースケース

appリソースと同じ値をpageリソースに代入したい時

## モチベーション

* 外部データを"pull"することを減らしたい
* 宣言的になる
* 簡素

## 検討点

リンクの`self`とは関係がありません。これと混同しないか。

```
    "_links": {
        "self": { "href": "/user" }
    }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Added self-linking functionality to resources, enhancing navigation and integration within the application.

- **Bug Fixes**
  - Removed an outdated dependency to ensure compatibility and performance.

- **Tests**
  - Introduced new tests to verify the functionality of self-linking in resources.

- **Refactor**
  - Updated PHP code style settings to exclude specific naming conventions for better clarity and consistency in method declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->