### PR TITLE
Make koriym/json-schema-faker package optional

### DIFF
--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -4,6 +4,7 @@
     "static", "self", "parent",
     "array", "string", "int", "float", "bool", "iterable", "callable", "void", "object",
     "Attribute", "ReflectionAttribute", "Stringable",
-    "BEAR\\Resource\\HalLink", "BEAR\\Resource\\NullReverseLink", "BEAR\\Resource\\ReverseLinkInterface", "BEAR\\Resource\\Module\\AnnotationModule"
+    "BEAR\\Resource\\HalLink", "BEAR\\Resource\\NullReverseLink", "BEAR\\Resource\\ReverseLinkInterface", "BEAR\\Resource\\Module\\AnnotationModule",
+    "JSONSchemaFaker\\Faker"
   ]
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "justinrainbow/json-schema": "^5.3 || ^6.0",
         "koriym/attributes": "^1.0",
         "koriym/http-constants": "^1.1",
-        "koriym/json-schema-faker": "^0.3",
         "nocarrier/hal": "^0.9.12",
         "phpdocumentor/reflection-docblock": "^5.2",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
@@ -37,7 +36,8 @@
         "ray/rector-ray": "^1.0",
         "rector/rector": "^1.2.4",
         "ray/compiler": "^1.9.1",
-        "bear/devtools": "^1.0"
+        "bear/devtools": "^1.0",
+        "koriym/json-schema-faker": "^0.3.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/JsonSchema/JsonSchemaExceptionFakeHandler.php
+++ b/src/JsonSchema/JsonSchemaExceptionFakeHandler.php
@@ -33,7 +33,7 @@ class JsonSchemaExceptionFakeHandler implements JsonSchemaExceptionHandlerInterf
     private function fakeResponse(string $schemaFile): array
     {
         if (! class_exists(Faker::class)) {
-            throw new LogicException('JSONSchemaFaker\Faker not installed. Please run "composer require koriym/json-schema-faker --dev". See more at https://github.com/bearsunday/BEAR.Resource/wiki/json_schema_faker_required'); // @codeCoverageIgnore
+            throw new LogicException('"koriym/json-schema-faker" not installed. Please run "composer require koriym/json-schema-faker --dev". See more at https://github.com/bearsunday/BEAR.Resource/wiki/json_schema_faker_required'); // @codeCoverageIgnore
         }
 
         /** @var array<int|string, mixed> $fakeObject */

--- a/src/JsonSchema/JsonSchemaExceptionFakeHandler.php
+++ b/src/JsonSchema/JsonSchemaExceptionFakeHandler.php
@@ -6,9 +6,11 @@ namespace BEAR\Resource;
 
 use BEAR\Resource\Exception\JsonSchemaException;
 use JSONSchemaFaker\Faker;
+use LogicException;
 use SplFileInfo;
 use stdClass;
 
+use function class_exists;
 use function is_object;
 
 class JsonSchemaExceptionFakeHandler implements JsonSchemaExceptionHandlerInterface
@@ -30,6 +32,10 @@ class JsonSchemaExceptionFakeHandler implements JsonSchemaExceptionHandlerInterf
     /** @return array<int|string, mixed> */
     private function fakeResponse(string $schemaFile): array
     {
+        if (! class_exists(Faker::class)) {
+            throw new LogicException('JSONSchemaFaker\Faker not installed. Please run "composer require koriym/json-schema-faker --dev". See more at https://github.com/bearsunday/BEAR.Resource/wiki/json_schema_faker_required'); // @codeCoverageIgnore
+        }
+
         /** @var array<int|string, mixed> $fakeObject */
         $fakeObject = (new Faker())->generate(new SplFileInfo($schemaFile));
 


### PR DESCRIPTION
Add a check to ensure JSONSchemaFaker\Faker class is present before usage. Updated the koriym/json-schema-faker dependency to version ^0.3.1 in composer.json and updated composer-require-checker.json accordingly.