### PR TITLE
Rector PHP 8.1: Refactor code for immutability and Rector setup enhancements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ray/aop": "^2.12.3",
         "ray/di": "^2.13",
         "ray/web-param-module": "^2.1.1",
-        "rize/uri-template": "^0.3"
+        "rize/uri-template": "^0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.10",

--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Php81\Rector\Array_\FirstClassCallableRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -17,6 +18,9 @@ return RectorConfig::configure()
     ->withTypeCoverageLevel(0)
     ->withDeadCodeLevel(0)
     ->withCodeQualityLevel(0)
+    ->withSkip([
+        FirstClassCallableRector::class
+    ])
     ->withSkip([
         __DIR__ . '/src/ResourceObject.php'
     ])

--- a/rector.php
+++ b/rector.php
@@ -3,27 +3,26 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Php74\Rector\FuncCall\ArraySpreadInsteadOfArrayMergeRector;
-use Rector\Php81\Rector\Array_\FirstClassCallableRector;
-use Rector\Set\ValueObject\LevelSetList;
 
-return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->paths([
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/demo',
         __DIR__ . '/src',
         __DIR__ . '/src-files',
-        __DIR__ . '/tests/*Test.php',
-        __DIR__ . '/tests-php8/*Test.php',
+        __DIR__ . '/tests',
+        __DIR__ . '/tests-php8',
+    ])
+    // uncomment to reach your current PHP version
+     ->withPhpSets(php81: true)
+    ->withTypeCoverageLevel(0)
+    ->withDeadCodeLevel(0)
+    ->withCodeQualityLevel(0)
+    ->withSkip([
+        __DIR__ . '/src/ResourceObject.php'
+    ])
+    ->withSkip([
+        __DIR__ . '/src/*Interface.php'
+    ])
+    ->withSkip([
+        __DIR__ . '/src/Abstract*.php'
     ]);
-    $rectorConfig->skip([
-       __DIR__ . '/src/*Interface.php'
-    ]);
-
-    // define sets of rules
-    $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_81,
-    ]);
-    $rectorConfig->skip([
-        FirstClassCallableRector::class,
-        ArraySpreadInsteadOfArrayMergeRector::class
-    ]);
-};

--- a/src-deprecated/HalLink.php
+++ b/src-deprecated/HalLink.php
@@ -14,7 +14,7 @@ use function uri_template;
 final class HalLink
 {
     public function __construct(
-        private ReverseLinkInterface $link,
+        private readonly ReverseLinkInterface $link,
     ) {
     }
 

--- a/src-deprecated/Param.php
+++ b/src-deprecated/Param.php
@@ -12,29 +12,11 @@ namespace BEAR\Resource;
 final class Param
 {
     /**
-     * @var string
-     */
-    public $class;
-
-    /**
-     * @var string
-     */
-    public $method;
-
-    /**
-     * @var string
-     */
-    public $param;
-
-    /**
      * @param string $class
      * @param string $method
      * @param string $param
      */
-    public function __construct($class, $method, $param)
+    public function __construct(public $class, public $method, public $param)
     {
-        $this->class = $class;
-        $this->method = $method;
-        $this->param = $param;
     }
 }

--- a/src-deprecated/VoidOptionsRenderer.php
+++ b/src-deprecated/VoidOptionsRenderer.php
@@ -14,8 +14,8 @@ final class VoidOptionsRenderer implements RenderInterface
     /**
      * {@inheritdoc}
      */
-    public function render(ResourceObject $ro)
+    public function render(ResourceObject $ro): never
     {
-        throw new MethodNotAllowedException(get_class($ro) . '::options', 405);
+        throw new MethodNotAllowedException($ro::class . '::options', 405);
     }
 }

--- a/src-deprecated/VoidParamHandler.php
+++ b/src-deprecated/VoidParamHandler.php
@@ -19,7 +19,7 @@ class VoidParamHandler implements ParamHandlerInterface
      *
      * @throws ParameterException
      */
-    public function handle(\ReflectionParameter $parameter)
+    public function handle(\ReflectionParameter $parameter): never
     {
         $class = $parameter->getDeclaringClass();
         $className = $class->implementsInterface(WeavedInterface::class) ? $class->getParentClass()->getName() : $class->name;

--- a/src/AssistedWebContextParam.php
+++ b/src/AssistedWebContextParam.php
@@ -36,11 +36,8 @@ final class AssistedWebContextParam implements ParamInterface
         assert(is_string($webContextParam::GLOBAL_KEY));
         /** @psalm-suppress MixedArrayOffset */
         $phpWebContext = $superGlobals[$webContextParam::GLOBAL_KEY];
-        if (isset($phpWebContext[$this->webContextParam->key])) {
-            return $phpWebContext[$this->webContextParam->key];
-        }
 
-        return ($this->defaultParam)($varName, $query, $injector);
+        return $phpWebContext[$this->webContextParam->key] ?? ($this->defaultParam)($varName, $query, $injector);
     }
 
     /** @param array<string, array<string, mixed>> $globals */

--- a/src/HttpRequestCurl.php
+++ b/src/HttpRequestCurl.php
@@ -15,7 +15,7 @@ use function curl_setopt;
 use function explode;
 use function http_build_query;
 use function json_decode;
-use function strpos;
+use function str_contains;
 use function strtolower;
 use function substr;
 use function trim;
@@ -40,7 +40,7 @@ use const CURLOPT_URL;
 final class HttpRequestCurl implements HttpRequestInterface
 {
     public function __construct(
-        private HttpRequestHeaders $requestHeaders,
+        private readonly HttpRequestHeaders $requestHeaders,
     ) {
     }
 
@@ -112,7 +112,7 @@ final class HttpRequestCurl implements HttpRequestInterface
     {
         $responseBody = [];
         $contentType = (string) curl_getinfo($curl, CURLINFO_CONTENT_TYPE);
-        if (strpos(strtolower($contentType), 'application/json') !== false) {
+        if (str_contains(strtolower($contentType), 'application/json')) {
             return (array) json_decode($view, true);
         }
 

--- a/src/HttpResourceObject.php
+++ b/src/HttpResourceObject.php
@@ -21,7 +21,7 @@ use function strtoupper;
 final class HttpResourceObject extends ResourceObject implements InvokeRequestInterface
 {
     public function __construct(
-        private HttpRequestInterface $httpRequest,
+        private readonly HttpRequestInterface $httpRequest,
     ) {
     }
 

--- a/src/Invoker.php
+++ b/src/Invoker.php
@@ -6,7 +6,7 @@ namespace BEAR\Resource;
 final class Invoker implements InvokerInterface
 {
     public function __construct(
-        private PhpClassInvoker $classInvoker
+        private readonly PhpClassInvoker $classInvoker
     ) {
     }
 

--- a/src/NoDefaultParam.php
+++ b/src/NoDefaultParam.php
@@ -12,7 +12,7 @@ final class NoDefaultParam implements ParamInterface
     /**
      * {@inheritDoc}
      */
-    public function __invoke(string $varName, array $query, InjectorInterface $injector)
+    public function __invoke(string $varName, array $query, InjectorInterface $injector): never
     {
         unset($query, $injector);
 

--- a/src/OptionalParam.php
+++ b/src/OptionalParam.php
@@ -31,10 +31,7 @@ final class OptionalParam implements ParamInterface
 
         // try camelCase variable name
         $snakeName = ltrim(strtolower((string) preg_replace('/[A-Z]/', '_\0', $varName)), '_');
-        if (isset($query[$snakeName])) {
-            return $query[$snakeName];
-        }
 
-        return $this->defaultValue;
+        return $query[$snakeName] ?? $this->defaultValue;
     }
 }

--- a/src/OptionsMethodRequest.php
+++ b/src/OptionsMethodRequest.php
@@ -41,11 +41,7 @@ final class OptionsMethodRequest
             return $this->getType($parameter);
         }
 
-        if (isset($paramDoc[$name]['type'])) {
-            return $paramDoc[$name]['type'];
-        }
-
-        return null;
+        return $paramDoc[$name]['type'] ?? null;
     }
 
     /**

--- a/src/PhpClassInvoker.php
+++ b/src/PhpClassInvoker.php
@@ -12,9 +12,9 @@ use function ucfirst;
 final class PhpClassInvoker implements InvokerInterface
 {
     public function __construct(
-        private NamedParameterInterface $params,
-        private ExtraMethodInvoker $extraMethod,
-        private LoggerInterface $logger,
+        private readonly NamedParameterInterface $params,
+        private readonly ExtraMethodInvoker $extraMethod,
+        private readonly LoggerInterface $logger,
     ) {
     }
 

--- a/tests/AnchorTest.php
+++ b/tests/AnchorTest.php
@@ -15,8 +15,6 @@ class AnchorTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $invoker = (new InvokerFactory())();
         $author = new Author();
         $author->onGet(1);

--- a/tests/AppIteratorTest.php
+++ b/tests/AppIteratorTest.php
@@ -23,7 +23,7 @@ class AppIteratorTest extends TestCase
 
     public function testForEach(): void
     {
-        foreach ($this->appIterator as $key => $meta) {
+        foreach ($this->appIterator as $meta) {
             $isValidUri = filter_var($meta->uri, FILTER_VALIDATE_URL);
             $this->assertTrue((bool) $isValidUri);
             $this->assertInstanceOf(Meta::class, $meta);

--- a/tests/AttrNamedParameterTest.php
+++ b/tests/AttrNamedParameterTest.php
@@ -15,8 +15,6 @@ class AttrNamedParameterTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->params = new NamedParameter(new NamedParamMetas(), new Injector());
     }
 

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -18,8 +18,6 @@ class AttributeTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $injector = new Injector(new ResourceModule('FakeVendor\News'), __DIR__ . '/tmp');
         $this->resource = $injector->getInstance(ResourceInterface::class);
     }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -21,8 +21,6 @@ class FactoryTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $injector = new Injector();
         $scheme = (new SchemeCollection())
             ->scheme('app')->host('self')->toAdapter(new AppAdapter($injector, 'FakeVendor\Sandbox'))

--- a/tests/Fake/FakeFreeze.php
+++ b/tests/Fake/FakeFreeze.php
@@ -16,7 +16,7 @@ class FakeFreeze extends ResourceObject
 
     public function __construct()
     {
-        $this->closure = function () {
+        $this->closure = function (): void {
         };
         $module = new FakeSchemeModule(new ResourceModule('FakeVendor\Sandbox'));
         /* @var $resource ResourceInterface */

--- a/tests/Fake/FakeLazyModule.php
+++ b/tests/Fake/FakeLazyModule.php
@@ -9,7 +9,7 @@ use Ray\Di\AbstractModule;
 
 final class FakeLazyModule implements LazyModuleInterface
 {
-    public function __construct(private AbstractModule $module)
+    public function __construct(private readonly AbstractModule $module)
     {
     }
 

--- a/tests/Fake/FakeSchemeCollectionProvider.php
+++ b/tests/Fake/FakeSchemeCollectionProvider.php
@@ -9,7 +9,7 @@ use Ray\Di\ProviderInterface;
 
 class FakeSchemeCollectionProvider implements ProviderInterface
 {
-    public function __construct(private InjectorInterface $injector)
+    public function __construct(private readonly InjectorInterface $injector)
     {
     }
 

--- a/tests/Fake/FakeVendor/Blog/src/Resource/App/News.php
+++ b/tests/Fake/FakeVendor/Blog/src/Resource/App/News.php
@@ -10,7 +10,7 @@ use BEAR\Resource\ResourceObject;
 
 class News extends ResourceObject
 {
-    public function __construct(private ResourceInterface $resource)
+    public function __construct(private readonly ResourceInterface $resource)
     {
     }
 

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/Href/Hasembed.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/Href/Hasembed.php
@@ -11,7 +11,7 @@ use BEAR\Resource\ResourceObject;
 
 class Hasembed extends ResourceObject
 {
-    public function __construct(private ResourceInterface $resource)
+    public function __construct(private readonly ResourceInterface $resource)
     {
     }
 

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/Href/Origin.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/Href/Origin.php
@@ -10,7 +10,7 @@ use BEAR\Resource\ResourceObject;
 
 class Origin extends ResourceObject
 {
-    public function __construct(private ResourceInterface $resource)
+    public function __construct(private readonly ResourceInterface $resource)
     {
     }
 

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/News.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/News.php
@@ -10,7 +10,7 @@ use BEAR\Resource\ResourceObject;
 
 class News extends ResourceObject
 {
-    public function __construct(private ResourceInterface $resource)
+    public function __construct(private readonly ResourceInterface $resource)
     {
     }
 

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/User/Entry.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/User/Entry.php
@@ -15,7 +15,7 @@ class Entry extends ResourceObject
         102 => ['id' => 102, 'title' => 'Entry3'],
     ];
 
-    public function __construct(private ?\BEAR\Resource\ResourceInterface $resource = null)
+    public function __construct(private readonly ?\BEAR\Resource\ResourceInterface $resource = null)
     {
     }
 

--- a/tests/Fake/FakeVendor/Sandbox/Resource/Page/FakeLoop.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/Page/FakeLoop.php
@@ -7,7 +7,7 @@ use BEAR\Resource\ResourceObject;
 
 class FakeLoop extends ResourceObject
 {
-    public function __construct(private ResourceInterface $resource)
+    public function __construct(private readonly ResourceInterface $resource)
     {
     }
 

--- a/tests/Fake/Mock/PersonConstructor.php
+++ b/tests/Fake/Mock/PersonConstructor.php
@@ -16,7 +16,7 @@ class PersonConstructor
         return $this->age;
     }
 
-    public function __construct(private int $age, private string $name)
+    public function __construct(private readonly int $age, private readonly string $name)
     {
     }
 }

--- a/tests/Fake/Renderer/FakeErrorRenderer.php
+++ b/tests/Fake/Renderer/FakeErrorRenderer.php
@@ -9,7 +9,7 @@ use BEAR\Resource\ResourceObject;
 
 class FakeErrorRenderer implements RenderInterface
 {
-    public function render(ResourceObject $ro)
+    public function render(ResourceObject $ro): never
     {
         throw new \ErrorException();
     }

--- a/tests/LinkerTest.php
+++ b/tests/LinkerTest.php
@@ -20,8 +20,6 @@ class LinkerTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->invoker = (new InvokerFactory())();
         $schemeCollection = (new SchemeCollection())
             ->scheme('app')

--- a/tests/MetaTest.php
+++ b/tests/MetaTest.php
@@ -15,8 +15,6 @@ class MetaTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->meta = new Meta(Doc::class);
     }
 

--- a/tests/Module/HalModuleTest.php
+++ b/tests/Module/HalModuleTest.php
@@ -16,7 +16,6 @@ class HalModuleTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
     }
 
     public function testConfigure(): void

--- a/tests/Module/ImportModuleTest.php
+++ b/tests/Module/ImportModuleTest.php
@@ -32,8 +32,6 @@ class ImportModuleTest extends TestCase
         $tmpDir = dirname(__DIR__, 2) . '/tests/Fake/FakeVendor/Blog/var/tmp';
         $rm($tmpDir);
         file_put_contents($tmpDir . '/tmp.text', '1');
-
-        parent::setUp();
     }
 
     public function testConfigure(): void

--- a/tests/Module/ResourceModuleTest.php
+++ b/tests/Module/ResourceModuleTest.php
@@ -13,7 +13,6 @@ class ResourceModuleTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
     }
 
     public function testConfigure(): void

--- a/tests/Module/ResrouceObjectModuleTest.php
+++ b/tests/Module/ResrouceObjectModuleTest.php
@@ -23,8 +23,6 @@ final class ResrouceObjectModuleTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         @unlink(__DIR__ . '/tmp/compiled');
         array_map('unlink', (array) glob(__DIR__ . '/tmp/{*.php}', GLOB_BRACE)); // @phpstan-ignore-line
     }

--- a/tests/NamedParameterTest.php
+++ b/tests/NamedParameterTest.php
@@ -22,8 +22,6 @@ class NamedParameterTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->params = new NamedParameter(new NamedParamMetas(), new Injector());
     }
 

--- a/tests/ObjectTest.php
+++ b/tests/ObjectTest.php
@@ -16,8 +16,6 @@ class ObjectTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->ro = new Mock\Entry();
         $this->ro[0] = 'entry1';
         $this->ro[1] = 'entry2';

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -27,8 +27,6 @@ class RequestTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->invoker = (new InvokerFactory())();
         $entry = new Entry();
         $entry->uri = new Uri('test://self/path/to/resource');

--- a/tests/ResourceParamHandlerTest.php
+++ b/tests/ResourceParamHandlerTest.php
@@ -15,8 +15,6 @@ class ResourceParamHandlerTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $module = new FakeSchemeModule(new ResourceModule('FakeVendor\Sandbox'));
         $this->resource = (new Injector($module, __DIR__ . '/tmp'))->getInstance(ResourceInterface::class);
     }

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -27,8 +27,6 @@ class ResourceTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $injector = new Injector(new FakeSchemeModule(new ResourceModule('FakeVendor\Sandbox')), __DIR__ . '/tmp');
         $this->resource = $injector->getInstance(ResourceInterface::class);
     }

--- a/tests/SchemeCollectionTest.php
+++ b/tests/SchemeCollectionTest.php
@@ -13,8 +13,6 @@ class SchemeCollectionTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->scheme = new SchemeCollection();
     }
 

--- a/tests/Server/index.php
+++ b/tests/Server/index.php
@@ -17,7 +17,7 @@ http_response_code(200);
 header('Content-Type: application/json; charset=utf-8');
 $requestHeaders = [];
 foreach ($_SERVER as $key => $value) {
-    if (strncmp($key, 'HTTP_', 5) !== 0) {
+    if (! str_starts_with($key, 'HTTP_')) {
         continue;
     }
 


### PR DESCRIPTION
---

- Enhanced code safety by updating class properties to `readonly` for immutability
- Simplified conditional structure and refined method return type hints for better type safety
- Updated Rector configuration using the new fluent API, enabling PHP 8.1 rules, and improving future maintainability
- Updated dependencies to permit the latest version of [rize/uri-](https://github.com/rize/UriTemplate)

Signed-off-by: dependabot[bot] <support@github.com>