### PR TITLE
Add request exception handler for JSON schema validation

### DIFF
--- a/src/JsonSchema/Interceptor/JsonSchemaInterceptor.php
+++ b/src/JsonSchema/Interceptor/JsonSchemaInterceptor.php
@@ -10,6 +10,7 @@ use BEAR\Resource\Exception\JsonSchemaException;
 use BEAR\Resource\Exception\JsonSchemaKeytNotFoundException;
 use BEAR\Resource\Exception\JsonSchemaNotFoundException;
 use BEAR\Resource\JsonSchemaExceptionHandlerInterface;
+use BEAR\Resource\JsonSchemaRequestExceptionHandlerInterface;
 use BEAR\Resource\ResourceObject;
 use JsonSchema\Constraints\Constraint;
 use JsonSchema\Validator;
@@ -40,6 +41,7 @@ final class JsonSchemaInterceptor implements JsonSchemaInterceptorInterface
         #[Named('json_validate_dir')]
         private readonly string $validateDir,
         private readonly JsonSchemaExceptionHandlerInterface $handler,
+        private readonly JsonSchemaRequestExceptionHandlerInterface $requestHandler,
         #[Named('json_schema_host')]
         private readonly string|null $schemaHost = null,
     ) {
@@ -55,7 +57,7 @@ final class JsonSchemaInterceptor implements JsonSchemaInterceptorInterface
         assert($jsonSchema instanceof JsonSchema);
         if ($jsonSchema->params) {
             $arguments = $this->getNamedArguments($invocation);
-            $this->validateRequest($jsonSchema, $arguments);
+            $this->validateRequest($invocation, $jsonSchema, $arguments);
         }
 
         $ro = $invocation->proceed();
@@ -68,11 +70,18 @@ final class JsonSchemaInterceptor implements JsonSchemaInterceptorInterface
     }
 
     /** @param array<string, mixed> $arguments */
-    private function validateRequest(JsonSchema $jsonSchema, array $arguments): void
+    private function validateRequest(MethodInvocation $invocation, JsonSchema $jsonSchema, array $arguments): void // @phpstan-ignore-line
     {
-        $schemaFile = $this->validateDir . '/' . $jsonSchema->params;
-        $this->validateFileExists($schemaFile);
-        $this->validate($arguments, $schemaFile);
+        try {
+            $schemaFile = $this->validateDir . '/' . $jsonSchema->params;
+            $this->validateFileExists($schemaFile);
+            $this->validate($arguments, $schemaFile);
+        } catch (JsonSchemaException $e) {
+            $ro = $invocation->getThis();
+            assert($ro instanceof ResourceObject);
+            /** @psalm-suppress PossiblyUndefinedVariable */
+            $this->requestHandler->handleRequestException($ro, $e, $schemaFile);
+        }
     }
 
     private function validateResponse(ResourceObject $ro, JsonSchema $jsonSchema): void

--- a/src/JsonSchema/JsonSchemaRequestExceptionHandlerInterface.php
+++ b/src/JsonSchema/JsonSchemaRequestExceptionHandlerInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource;
+
+use BEAR\Resource\Exception\JsonSchemaException;
+
+interface JsonSchemaRequestExceptionHandlerInterface
+{
+    /**
+     * Handle invalid request object
+     *
+     * @return void
+     */
+    public function handleRequestException(ResourceObject $ro, JsonSchemaException $e, string $schemaFile);
+}

--- a/src/JsonSchema/JsonSchemaRequestExceptionNullHandler.php
+++ b/src/JsonSchema/JsonSchemaRequestExceptionNullHandler.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource;
+
+use BEAR\Resource\Exception\JsonSchemaException;
+
+class JsonSchemaRequestExceptionNullHandler implements JsonSchemaRequestExceptionHandlerInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function handleRequestException(ResourceObject $ro, JsonSchemaException $e, string $schemaFile)
+    {
+        throw $e;
+    }
+}

--- a/src/JsonSchema/Module/JsonSchemaModule.php
+++ b/src/JsonSchema/Module/JsonSchemaModule.php
@@ -9,6 +9,8 @@ use BEAR\Resource\Interceptor\JsonSchemaInterceptor;
 use BEAR\Resource\Interceptor\JsonSchemaInterceptorInterface;
 use BEAR\Resource\JsonSchemaExceptionHandlerInterface;
 use BEAR\Resource\JsonSchemaExceptionNullHandler;
+use BEAR\Resource\JsonSchemaRequestExceptionHandlerInterface;
+use BEAR\Resource\JsonSchemaRequestExceptionNullHandler;
 use BEAR\Resource\ResourceObject;
 use Ray\Di\AbstractModule;
 
@@ -34,6 +36,7 @@ class JsonSchemaModule extends AbstractModule
         $this->bind()->annotatedWith('json_schema_dir')->toInstance($this->jsonSchemaDir);
         $this->bind()->annotatedWith('json_validate_dir')->toInstance($this->jsonValidateDir);
         $this->bind(JsonSchemaExceptionHandlerInterface::class)->to(JsonSchemaExceptionNullHandler::class);
+        $this->bind(JsonSchemaRequestExceptionHandlerInterface::class)->to(JsonSchemaRequestExceptionNullHandler::class);
         $this->bind(JsonSchemaInterceptorInterface::class)->to(JsonSchemaInterceptor::class);
         $this->bindInterceptor(
             $this->matcher->subclassesOf(ResourceObject::class),

--- a/tests/JsonSchema/Interceptor/JsonSchemaInterceptorTest.php
+++ b/tests/JsonSchema/Interceptor/JsonSchemaInterceptorTest.php
@@ -9,6 +9,7 @@ use BEAR\Resource\Interceptor\JsonSchemaInterceptor;
 use BEAR\Resource\JsonSchema\FakeUser;
 use BEAR\Resource\JsonSchema\FakeView;
 use BEAR\Resource\JsonSchemaExceptionNullHandler;
+use BEAR\Resource\JsonSchemaRequestExceptionNullHandler;
 use BEAR\Resource\ResourceObject;
 use PHPUnit\Framework\TestCase;
 use Ray\Aop\MethodInterceptor;
@@ -27,6 +28,7 @@ class JsonSchemaInterceptorTest extends TestCase
             $fakeDir . '/Fake/json_schema',
             $fakeDir . '/Fake/json_validate',
             new JsonSchemaExceptionNullHandler(),
+            new JsonSchemaRequestExceptionNullHandler(),
             'http://example.com/schema/',
         );
     }


### PR DESCRIPTION
closes #199
cc/ @sosuke-ito

## Summary by Sourcery

This pull request introduces a mechanism to handle exceptions that occur during JSON schema validation of requests. It provides an interface for handling these exceptions and a default implementation that simply re-throws the exception. The JSON schema interceptor is updated to use this new handler.

New Features:
- Introduces a new `JsonSchemaRequestExceptionHandlerInterface` to handle exceptions during JSON schema validation of requests.
- Adds a default `JsonSchemaRequestExceptionNullHandler` implementation that re-throws the exception.

Enhancements:
- The `JsonSchemaInterceptor` now catches `JsonSchemaException` during request validation and delegates handling to the new exception handler.

## Summary by Sourcery

This pull request introduces a mechanism to handle exceptions that occur during JSON schema validation of requests. It provides an interface for handling these exceptions and a default implementation that simply re-throws the exception. The JSON schema interceptor is updated to use this new handler.

New Features:
- Introduces `JsonSchemaRequestExceptionHandlerInterface` to allow handling of exceptions during JSON schema validation of requests.
- Adds a default `JsonSchemaRequestExceptionNullHandler` implementation that re-throws the exception.

Enhancements:
- The `JsonSchemaInterceptor` now catches `JsonSchemaException` during request validation and delegates handling to the new exception handler.