### PR TITLE
Pass arguments to JsonSchemaRequestExceptionHandlerInterface

### DIFF
--- a/src/ClassParam.php
+++ b/src/ClassParam.php
@@ -60,7 +60,7 @@ final class ClassParam implements ParamInterface
         }
 
         assert(class_exists($this->type));
-        $refClass = (new ReflectionClass($this->type));
+        $refClass = new ReflectionClass($this->type);
 
         if ($refClass->isEnum()) {
             return $this->enum($this->type, $props, $varName);

--- a/src/JsonSchema/Interceptor/JsonSchemaInterceptor.php
+++ b/src/JsonSchema/Interceptor/JsonSchemaInterceptor.php
@@ -80,7 +80,7 @@ final class JsonSchemaInterceptor implements JsonSchemaInterceptorInterface
             $ro = $invocation->getThis();
             assert($ro instanceof ResourceObject);
             /** @psalm-suppress PossiblyUndefinedVariable */
-            $this->requestHandler->handleRequestException($ro, $e, $schemaFile, $arguments);
+            $this->requestHandler->handleRequestException($arguments, $ro, $e, $schemaFile);
         }
     }
 

--- a/src/JsonSchema/Interceptor/JsonSchemaInterceptor.php
+++ b/src/JsonSchema/Interceptor/JsonSchemaInterceptor.php
@@ -80,7 +80,7 @@ final class JsonSchemaInterceptor implements JsonSchemaInterceptorInterface
             $ro = $invocation->getThis();
             assert($ro instanceof ResourceObject);
             /** @psalm-suppress PossiblyUndefinedVariable */
-            $this->requestHandler->handleRequestException($ro, $e, $schemaFile);
+            $this->requestHandler->handleRequestException($ro, $e, $schemaFile, $arguments);
         }
     }
 

--- a/src/JsonSchema/JsonSchemaRequestExceptionHandlerInterface.php
+++ b/src/JsonSchema/JsonSchemaRequestExceptionHandlerInterface.php
@@ -16,9 +16,9 @@ interface JsonSchemaRequestExceptionHandlerInterface
      * @return void
      */
     public function handleRequestException(
+        array $arguments,
         ResourceObject $ro,
         JsonSchemaException $e,
         string $schemaFile,
-        array $arguments,
     );
 }

--- a/src/JsonSchema/JsonSchemaRequestExceptionHandlerInterface.php
+++ b/src/JsonSchema/JsonSchemaRequestExceptionHandlerInterface.php
@@ -11,7 +11,14 @@ interface JsonSchemaRequestExceptionHandlerInterface
     /**
      * Handle invalid request object
      *
+     * @param array<string, mixed> $arguments
+     *
      * @return void
      */
-    public function handleRequestException(ResourceObject $ro, JsonSchemaException $e, string $schemaFile);
+    public function handleRequestException(
+        ResourceObject $ro,
+        JsonSchemaException $e,
+        string $schemaFile,
+        array $arguments,
+    );
 }

--- a/src/JsonSchema/JsonSchemaRequestExceptionNullHandler.php
+++ b/src/JsonSchema/JsonSchemaRequestExceptionNullHandler.php
@@ -12,10 +12,10 @@ class JsonSchemaRequestExceptionNullHandler implements JsonSchemaRequestExceptio
      * {@inheritDoc}
      */
     public function handleRequestException(
+        array $arguments,
         ResourceObject $ro,
         JsonSchemaException $e,
         string $schemaFile,
-        array $arguments,
     ) {
         throw $e;
     }

--- a/src/JsonSchema/JsonSchemaRequestExceptionNullHandler.php
+++ b/src/JsonSchema/JsonSchemaRequestExceptionNullHandler.php
@@ -11,8 +11,12 @@ class JsonSchemaRequestExceptionNullHandler implements JsonSchemaRequestExceptio
     /**
      * {@inheritDoc}
      */
-    public function handleRequestException(ResourceObject $ro, JsonSchemaException $e, string $schemaFile)
-    {
+    public function handleRequestException(
+        ResourceObject $ro,
+        JsonSchemaException $e,
+        string $schemaFile,
+        array $arguments
+    ) {
         throw $e;
     }
 }

--- a/src/JsonSchema/JsonSchemaRequestExceptionNullHandler.php
+++ b/src/JsonSchema/JsonSchemaRequestExceptionNullHandler.php
@@ -15,7 +15,7 @@ class JsonSchemaRequestExceptionNullHandler implements JsonSchemaRequestExceptio
         ResourceObject $ro,
         JsonSchemaException $e,
         string $schemaFile,
-        array $arguments
+        array $arguments,
     ) {
         throw $e;
     }


### PR DESCRIPTION
## Overview

This PR updates the way `JsonSchemaException` is handled within `JsonSchemaInterceptor` by including the method’s arguments (`$arguments`) when invoking `handleRequestException`. Specifically, the following changes have been made:

- Updated the `handleRequestException` signature in `JsonSchemaRequestExceptionHandlerInterface` to accept `$arguments`.
- Modified the corresponding implementation class (`JsonSchemaRequestExceptionNullHandler`) to reflect the new signature.
- Changed the call to `handleRequestException` in `JsonSchemaInterceptor` to include `$arguments`.

### Main Objective

- Provide more detailed and flexible error handling by allowing access to the request arguments when an exception is thrown, enabling better debugging and error processing.

## Summary by Sourcery

Enhancements:
- Pass the method's arguments to the `JsonSchemaRequestExceptionHandlerInterface` to provide more context for error handling.