### PR TITLE
fix: handle InvalidArgumentException from Ray.InputQuery in parameter resolution

### DIFF
--- a/src/NamedParameter.php
+++ b/src/NamedParameter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace BEAR\Resource;
 
+use BEAR\Resource\Exception\ParameterException;
+use InvalidArgumentException;
 use Override;
 use Ray\Di\InjectorInterface;
 
@@ -17,6 +19,8 @@ final class NamedParameter implements NamedParameterInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @throws ParameterException Thrown when the query parameter is invalid.
      */
     #[Override]
     public function getParameters(callable $callable, array $query): array
@@ -24,8 +28,14 @@ final class NamedParameter implements NamedParameterInterface
         $metas = ($this->paramMetas)($callable);
         $parameters = [];
         foreach ($metas as $varName => $param) {
+
             /** @psalm-suppress MixedAssignment */
-            $parameters[$varName] = $param($varName, $query, $this->injector);
+            try {
+                $parameters[$varName] = $param($varName, $query, $this->injector);
+            } catch (InvalidArgumentException $e) {
+                // handle missing query parameter in Ray.InputQuery
+                throw new ParameterException($varName, $e->getCode(), $e);
+            }
         }
 
         return $parameters;

--- a/tests/Fake/FakeVendor/Sandbox/Resource/App/User.php
+++ b/tests/Fake/FakeVendor/Sandbox/Resource/App/User.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace FakeVendor\Sandbox\Resource\App;
 
+use BEAR\Resource\Exception\ParameterException;
 use BEAR\Resource\ResourceObject;
 
 class User extends ResourceObject
@@ -21,7 +22,7 @@ class User extends ResourceObject
     public function onGet(int $id)
     {
         if (! isset($this->users[$id])) {
-            throw new \InvalidArgumentException((string) $id);
+            throw new ParameterException((string) $id);
         }
 
         return $this->users[$id];

--- a/tests/InvokerTest.php
+++ b/tests/InvokerTest.php
@@ -17,7 +17,6 @@ use FakeVendor\Sandbox\Resource\App\Doc;
 use FakeVendor\Sandbox\Resource\App\Restbucks\Order;
 use FakeVendor\Sandbox\Resource\App\User;
 use FakeVendor\Sandbox\Resource\App\Weave\Book;
-use InvalidArgumentException;
 use LogicException;
 use PHPUnit\Framework\TestCase;
 use Ray\Aop\Bind;
@@ -196,7 +195,7 @@ class InvokerTest extends TestCase
 
     public function testInvokeExceptionHandle(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(ParameterException::class);
         $outOfRangeId = 4;
         $request = new Request($this->invoker, new User(), Request::GET, ['id' => $outOfRangeId]);
         $this->invoker->invoke($request);

--- a/tests/PassingFileUploadObjectTest.php
+++ b/tests/PassingFileUploadObjectTest.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 
 namespace BEAR\Resource;
 
+use BEAR\Resource\Exception\ParameterException;
 use BEAR\Resource\Module\ResourceModule;
-use InvalidArgumentException;
 use Koriym\FileUpload\FileUpload;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
@@ -33,40 +33,40 @@ class PassingFileUploadObjectTest extends TestCase
 
     public function testInputFormParamInvalidStringType(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(ParameterException::class);
 
         $this->resource->post('app://self/file-upload', ['image' => 'invalid_string']);
     }
 
     public function testInputFormParamInvalidIntType(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(ParameterException::class);
 
         $this->resource->post('app://self/file-upload', ['image' => 123]);
     }
 
     public function testInputFormParamInvalidArrayType(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(ParameterException::class);
 
         $this->resource->post('app://self/file-upload', ['image' => []]);
     }
 
     public function testInputFormsParamInvalidNonArrayType(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(ParameterException::class);
         $this->resource->put('app://self/file-upload', ['files' => 'not_an_array']);
     }
 
     public function testInputFormsParamInvalidArrayElementString(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(ParameterException::class);
         $this->resource->put('app://self/file-upload', ['files' => ['invalid_string']]);
     }
 
     public function testInputFormsParamInvalidArrayElementInt(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(ParameterException::class);
         $this->resource->put('app://self/file-upload', [
             'files' => [
                 FileUpload::fromFile(__DIR__ . '/Fake/app.svg'),


### PR DESCRIPTION
Close #330

## Summary

This PR fixes an issue introduced when Ray.InputQuery integration was added to BEAR.Resource. Previously, when empty queries were passed to resource methods, `ParameterException` was consistently thrown for missing parameters. However, with Ray.InputQuery integration, `InvalidArgumentException` is thrown instead, which was not being caught by `NamedParameter::getParameters()`.

## Problem

- Ray.InputQuery throws `InvalidArgumentException` for missing/invalid parameters
- `NamedParameter` was not catching these exceptions
- This caused unhandled exceptions to bubble up when empty queries were passed to resource methods
- Broke the consistent exception handling that consumers expected

## Solution

- Added try-catch block in `NamedParameter::getParameters()` to catch `InvalidArgumentException`
- Convert `InvalidArgumentException` to `ParameterException` to maintain framework consistency
- Preserve original exception context through proper exception chaining
- Added appropriate documentation with `@throws` annotation

## Benefits

- ✅ Maintains backward compatibility for exception handling
- ✅ Preserves BEAR.Resource's exception hierarchy
- ✅ Provides clear separation of concerns between packages
- ✅ Maintains debugging information through exception chaining
- ✅ No breaking changes to public API

## Design Decision

After careful consideration of which package should own which exceptions, we decided:
- Ray.InputQuery should throw `InvalidArgumentException` (generic, input-related)
- BEAR.Resource should catch and convert to `ParameterException` (framework-specific)
- This maintains proper package boundaries and exception ownership

## Test plan

- [x] Verify empty query parameters are properly handled
- [x] Confirm `ParameterException` is thrown (not `InvalidArgumentException`)
- [x] Validate exception chaining preserves debugging context
- [x] Test backward compatibility with existing error handling

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Catch and convert InvalidArgumentException from Ray.InputQuery to ParameterException in NamedParameter::getParameters to restore consistent parameter error handling and document the change.

Bug Fixes:
- Catch InvalidArgumentException in NamedParameter::getParameters and rethrow as ParameterException for missing or invalid query parameters.

Enhancements:
- Preserve original exception context through proper exception chaining.

Documentation:
- Add @throws annotation to document the new ParameterException in NamedParameter::getParameters.