### PR TITLE
Update `ray/input-query` dependency to version ^0.3.0.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ray/web-param-module": "^2.1.1",
         "rize/uri-template": "^0.4",
         "symfony/polyfill-php83": "^v1.32",
-        "ray/input-query": "^0.2.0",
+        "ray/input-query": "^0.3.0",
         "koriym/file-upload": "^0.2.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update ray/input-query version constraint from ^0.2.0 to ^0.3.0