### PR TITLE
update ray/input-query dependency to ^1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.26.3] - 2025-07-30
+
+### Changed
+- Updated `ray/input-query` dependency to version ^1.0
+
 ## [1.26.2] - 2025-07-17
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ray/web-param-module": "^2.1.1",
         "rize/uri-template": "^0.4",
         "symfony/polyfill-php83": "^v1.32",
-        "ray/input-query": "^0.3.0",
+        "ray/input-query": "^1.0",
         "koriym/file-upload": "^0.2.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary
- Update ray/input-query dependency from ^0.3.0 to ^1.0
- Update CHANGELOG.md for version 1.26.3

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Bump ray/input-query dependency to ^1.0 and document the change in CHANGELOG for v1.26.3

Enhancements:
- Upgrade ray/input-query dependency to ^1.0

Documentation:
- Add CHANGELOG entry for version 1.26.3 reflecting the dependency update