### PR TITLE
Remove obsolete @CookieParam annotation docblocks

### DIFF
--- a/tests/Fake/FakeParamResource.php
+++ b/tests/Fake/FakeParamResource.php
@@ -16,15 +16,6 @@ class FakeParamResource extends ResourceObject
     {
     }
 
-    /**
-     * @CookieParam(param="cookie", key="c")
-     * @EnvParam(param="env", key="e")
-     * @FormParam(param="form", key="f")
-     * @QueryParam(param="query", key="q")
-     * @ServerParam(param="server", key="s")
-     *
-     * @see attribute version at FakeParamResourceParam
-     */
     public function onPost(
         #[CookieParam('c')] string $cookie,
         #[EnvParam('e')] string $env,
@@ -34,16 +25,10 @@ class FakeParamResource extends ResourceObject
     ) {
     }
 
-    /**
-     * @CookieParam(param="cookie", key="c")
-     */
     public function onPut(#[CookieParam('c')] string $cookie)
     {
     }
 
-    /**
-     * @CookieParam(param="cookie", key="c")
-     */
     public function onDelete(string $a, #[CookieParam('c')] string $cookie = 'default')
     {
     }


### PR DESCRIPTION
Remove old annotation-style docblock comments for @CookieParam since the parameters already use #[CookieParam] attributes.

- Removed redundant docblocks from FakeParamResource test class
- Tests pass (282 tests, 462 assertions)

## Summary by Sourcery

Enhancements:
- Remove redundant @CookieParam, @EnvParam, @FormParam, @QueryParam, and @ServerParam docblocks from resource methods