### PR TITLE
Upgrade to PHPUnit 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 /coverage.xml
 /tests/log/error.log
 /tests-php8/*
-/.phpunit-cache
+/.phpunit.cache
 /CLAUDE.md
 /memo.txt
 

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,12 +1,12 @@
 build:
+    image: default-jammy
+    environment:
+        php: 8.4
     nodes:
         analysis:
             tests:
                 override:
                     - php-scrutinizer-run
-            environment:
-                php:
-                    version: 8.3.16
 
 filter:
     paths: ["src/*"]

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "ext-fileinfo": "*",
         "justinrainbow/json-schema": "^5.3 || ^6.0",
         "koriym/http-constants": "^1.1",
-        "nocarrier/hal": "^0.9.12",
+        "koriym/hal": "^1.1",
         "phpdocumentor/reflection-docblock": "^5.2",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "ray/aop": "^2.18.0",

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "nocarrier/hal": "^0.9.12",
         "phpdocumentor/reflection-docblock": "^5.2",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
-        "ray/aop": "dev-php82 as 2.19.0",
-        "ray/di": "dev-php82 as 2.19.0",
+        "ray/aop": "^2.18.0",
+        "ray/di": "^2.18.0",
         "rize/uri-template": "^0.4",
         "symfony/polyfill-php83": "^v1.32",
         "ray/input-query": "^1.0",
@@ -30,7 +30,7 @@
         "phpunit/phpunit": "^9.6.29",
         "bear/devtools": "^1.0",
         "koriym/json-schema-faker": "^0.3.1",
-        "ray/compiler": "dev-php82 as 1.13.0",
+        "ray/compiler": "^1.12",
         "bamarni/composer-bin-plugin": "^1.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "koriym/file-upload": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.6.29",
+        "phpunit/phpunit": "^11.0",
         "bear/devtools": "^1.0",
         "koriym/json-schema-faker": "^0.3.1",
         "ray/compiler": "^1.12",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,5 @@
 <?xml version="1.0"?>
-<phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-        bootstrap="tests/bootstrap.php">
-  <coverage processUncoveredFiles="true" cacheDirectory="./.phpunit-cache">
-    <include>
-      <directory suffix=".php">src</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd" bootstrap="tests/bootstrap.php" cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="BEAR.Resource Test Suite">
       <directory>tests</directory>
@@ -16,4 +8,9 @@
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/rector.php
+++ b/rector.php
@@ -3,23 +3,24 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Php81\Rector\Array_\FirstClassCallableRector;
+use Rector\PHPUnit\Set\PHPUnitSetList;
 
 return RectorConfig::configure()
     ->withPaths([
         __DIR__ . '/demo',
         __DIR__ . '/src',
         __DIR__ . '/src-files',
+        __DIR__ . '/src-web-context',
         __DIR__ . '/tests',
     ])
     // uncomment to reach your current PHP version
-     ->withPhpSets(php82: true)
-    ->withTypeCoverageLevel(0)
-    ->withDeadCodeLevel(0)
-    ->withCodeQualityLevel(0)
-    ->withSkip([
-        FirstClassCallableRector::class
+    // ->withPhpSets()
+    ->withSets([
+        PHPUnitSetList::PHPUNIT_110,
     ])
+    ->withTypeCoverageLevel(1)
+    ->withDeadCodeLevel(1)
+    ->withCodeQualityLevel(1)
     ->withSkip([
         __DIR__ . '/src/ResourceObject.php'
     ])
@@ -29,3 +30,4 @@ return RectorConfig::configure()
     ->withSkip([
         __DIR__ . '/src/Abstract*.php'
     ]);
+

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -7,6 +7,7 @@ namespace BEAR\Resource;
 use BEAR\Resource\Module\ResourceModule;
 use FakeVendor\News\Resource\App\News;
 use FakeVendor\News\Resource\App\WebParam;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
 
@@ -31,17 +32,15 @@ class AttributeTest extends TestCase
         return $instance;
     }
 
-    /** @depends testNewInstance */
+    #[Depends('testNewInstance')]
     public function testEmbeded(News $news): void
     {
         $ro = $news->onGet('2021/7/23');
         $this->assertInstanceOf(Request::class, $ro->body['weather']);
     }
 
-    /**
-     * @depends testNewInstance
-     * @see ResourceTest::testLinkSelf()
-     */
+    /** @see ResourceTest::testLinkSelf() */
+    #[Depends('testNewInstance')]
     public function testLink(News $news): void
     {
         $request = $this->resource->get->uri('app://self/news')->withQuery(['date' => '2021/7/23'])->linkSelf('event')->request();

--- a/tests/EmbedInterceptorTest.php
+++ b/tests/EmbedInterceptorTest.php
@@ -10,6 +10,7 @@ use BEAR\Resource\Module\ResourceModule;
 use FakeVendor\Sandbox\Resource\App\Bird\Birds;
 use FakeVendor\Sandbox\Resource\App\Bird\BirdsRel;
 use FakeVendor\Sandbox\Resource\App\Bird\Sparrow;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
 
@@ -57,7 +58,7 @@ class EmbedInterceptorTest extends TestCase
         return $result;
     }
 
-    /** @depends testInvoke */
+    #[Depends('testInvoke')]
     public function testInvokeAnotherLink(ResourceObject $result): ResourceObject
     {
         $profile = $result['bird2'];
@@ -68,7 +69,7 @@ class EmbedInterceptorTest extends TestCase
         return $result;
     }
 
-    /** @depends testInvoke */
+    #[Depends('testInvoke')]
     public function testInvokeString(ResourceObject $result): void
     {
         $result->setRenderer(new JsonRenderer());
@@ -94,7 +95,7 @@ class EmbedInterceptorTest extends TestCase
         return $bird2;
     }
 
-    /** @depends testEmbedAnnotation */
+    #[Depends('testEmbedAnnotation')]
     public function testEmbedChangeQuery(AbstractRequest $request): void
     {
         $request->withQuery(['id' => 100]);

--- a/tests/HttpResourceObjectTest.php
+++ b/tests/HttpResourceObjectTest.php
@@ -6,6 +6,7 @@ namespace BEAR\Resource;
 
 use BEAR\Dev\Http\BuiltinServer;
 use BEAR\Resource\Module\ResourceModule;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\AbstractModule;
 use Ray\Di\Injector;
@@ -80,14 +81,14 @@ class HttpResourceObjectTest extends TestCase
         $this->assertSame('bar', $body['form']['foo']);  // @phpstan-ignore-line
     }
 
-    /** @depends testGet */
+    #[Depends('testGet')]
     public function testToString(HttpResourceObject $response): void
     {
         $actual = (string) $response;
         $this->assertStringContainsString('"args": {', $actual);
     }
 
-    /** @depends testGet */
+    #[Depends('testGet')]
     public function testIsSet(HttpResourceObject $response): void
     {
         $isSet = isset($response->invalid);

--- a/tests/InvokerTest.php
+++ b/tests/InvokerTest.php
@@ -18,6 +18,7 @@ use FakeVendor\Sandbox\Resource\App\Restbucks\Order;
 use FakeVendor\Sandbox\Resource\App\User;
 use FakeVendor\Sandbox\Resource\App\Weave\Book;
 use LogicException;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use Ray\Aop\Bind;
 use Ray\Aop\Compiler;
@@ -98,7 +99,7 @@ class InvokerTest extends TestCase
         return (string) $response->view;
     }
 
-    /** @depends testOptionsMethod */
+    #[Depends('testOptionsMethod')]
     public function testOptionsMethodBody(string $view): void
     {
         $expected = '{

--- a/tests/Module/DevLoggerModuleTest.php
+++ b/tests/Module/DevLoggerModuleTest.php
@@ -7,6 +7,7 @@ namespace BEAR\Resource\Module;
 use BEAR\Resource\DevLogger;
 use BEAR\Resource\FakeResource;
 use BEAR\Resource\LoggerInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Ray\Di\AbstractModule;
@@ -14,12 +15,10 @@ use Ray\Di\Injector;
 
 use function assert;
 
+#[CoversClass(DevLogger::class)]
+#[CoversClass(DevLoggerModule::class)]
 class DevLoggerModuleTest extends TestCase
 {
-    /**
-     * @covers \BEAR\Resource\DevLogger
-     * @covers \BEAR\Resource\Module\DevLoggerModule
-     */
     public function testDevLoggerModule(): void
     {
         $psrLoggerModule = new class extends AbstractModule {

--- a/tests/Module/JsonSchemaModuleTest.php
+++ b/tests/Module/JsonSchemaModuleTest.php
@@ -13,6 +13,7 @@ use BEAR\Resource\JsonSchema\FakeUsers;
 use BEAR\Resource\ResourceObject;
 use BEAR\Resource\Uri;
 use LogicException;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use Ray\Aop\NullInterceptor;
 use Ray\Di\Injector;
@@ -54,7 +55,7 @@ class JsonSchemaModuleTest extends TestCase
         return $e;
     }
 
-    /** @depends testValidateException */
+    #[Depends('testValidateException')]
     public function testBCValidateErrorException(JsonSchemaException $e): void
     {
         $this->assertStringContainsString('[age]', $e->getMessage());

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -7,6 +7,8 @@ namespace BEAR\Resource;
 use FakeVendor\Sandbox\Resource\App\DocInvalidFile;
 use FakeVendor\Sandbox\Resource\App\DocPhp7;
 use FakeVendor\Sandbox\Resource\App\DocUser;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 
 /** @psalm-import-type Query from Types */
@@ -36,7 +38,7 @@ class OptionsTest extends TestCase
         return $ro;
     }
 
-    /** @depends testOptionsMethod */
+    #[Depends('testOptionsMethod')]
     public function testOptionsMethodBody(ResourceObject $ro): void
     {
         $actual = (string) $ro->view;
@@ -104,7 +106,7 @@ class OptionsTest extends TestCase
     }
 
     /** @return ResourceObject[][] */
-    public function roProvider(): array
+    public static function roProvider(): array
     {
         return [
             [new FakeParamResource()],
@@ -112,7 +114,7 @@ class OptionsTest extends TestCase
         ];
     }
 
-    /** @dataProvider roProvider */
+    #[DataProvider('roProvider')]
     public function testAssistedResource(ResourceObject $ro): void
     {
         $request = new Request($this->invoker, $ro, Request::OPTIONS);

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -11,6 +11,7 @@ use BEAR\Resource\Renderer\FakeTestRenderer;
 use FakeVendor\Sandbox\Resource\App\User\Entry;
 use LogicException;
 use OutOfRangeException;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 
 use function restore_error_handler;
@@ -294,14 +295,14 @@ class RequestTest extends TestCase
         return $request;
     }
 
-    /** @depends testCode */
+    #[Depends('testCode')]
     public function testHeaders(Request $request): void
     {
         $headers = $request->headers;
         $this->assertSame([], $headers);
     }
 
-    /** @depends testCode */
+    #[Depends('testCode')]
     public function testBody(Request $request): void
     {
         $body = $request->body;
@@ -309,7 +310,7 @@ class RequestTest extends TestCase
         $this->assertSame($expected, $body);
     }
 
-    /** @depends testCode */
+    #[Depends('testCode')]
     public function testInvalidProp(Request $request): void
     {
         $this->expectException(OutOfRangeException::class);

--- a/tests/ResourceObjectTest.php
+++ b/tests/ResourceObjectTest.php
@@ -51,7 +51,6 @@ class ResourceObjectTest extends TestCase
         $this->assertSame($expected, $json);
     }
 
-    /** @covers \BEAR\Resource\ResourceObject::toString() */
     public function testViewCached(): void
     {
         $ro = new FakeResource();
@@ -61,7 +60,6 @@ class ResourceObjectTest extends TestCase
         $this->assertSame($view, $ro->toString());
     }
 
-    /** @covers \BEAR\Resource\ResourceObject::count() */
     public function testIlligalAccessExceptionInCount(): void
     {
         $this->expectException(IlligalAccessException::class);
@@ -79,7 +77,6 @@ class ResourceObjectTest extends TestCase
         $this->assertSame(null, $wakeup->body['req']->body); // @phpstan-ignore-line
     }
 
-    /** @covers \BEAR\Resource\ResourceObject::offsetExists() */
     public function testIlligalAccessExceptionInOffsetExists(): void
     {
         $ro = new FakeResource();
@@ -87,7 +84,6 @@ class ResourceObjectTest extends TestCase
         $this->assertFalse(isset($ro['key']));
     }
 
-    /** @covers \BEAR\Resource\ResourceObject::offsetGet() */
     public function testIlligalAccessExceptionInOffsetGet(): void
     {
         $this->expectException(IlligalAccessException::class);

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -13,6 +13,7 @@ use FakeVendor\Sandbox\Resource\App\Href\Hasembed;
 use FakeVendor\Sandbox\Resource\App\Href\Origin;
 use FakeVendor\Sandbox\Resource\App\Href\Target;
 use FakeVendor\Sandbox\Resource\Page\Index;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
 use Ray\Di\NullModule;
@@ -240,7 +241,7 @@ class ResourceTest extends TestCase
         return $this->resource;
     }
 
-    /** @depends testAssistedParameter */
+    #[Depends('testAssistedParameter')]
     public function testPreventAssistedParameterOverride(ResourceInterface $resource): void
     {
         $ro = $resource->get->uri('page://self/assist')->withQuery(['login_id' => '_WILL_BE_IGNORED_'])->eager->request();
@@ -315,7 +316,6 @@ class ResourceTest extends TestCase
         $this->assertJsonStringEqualsJsonString($expected, $view);
     }
 
-    /** @covers \BEAR\Resource\Resource::options() */
     public function testOptions(): void
     {
         $ro = $this->resource->options('page://self/index');

--- a/tests/ShortSyntaxTest.php
+++ b/tests/ShortSyntaxTest.php
@@ -6,6 +6,7 @@ namespace BEAR\Resource;
 
 use BEAR\Resource\Module\ResourceModule;
 use FakeVendor\Sandbox\Resource\Page\Index;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
 
@@ -54,7 +55,7 @@ class ShortSyntaxTest extends TestCase
         return $index;
     }
 
-    /** @depends testShortSyntaxFunction */
+    #[Depends('testShortSyntaxFunction')]
     public function testShortSyntaxReuseRequest(AbstractRequest $index): void
     {
         $ro = $index(['id' => 'bear']);

--- a/vendor-bin/tools/composer.lock
+++ b/vendor-bin/tools/composer.lock
@@ -2734,16 +2734,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "4.0.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "06113cfdaf117fc2165f9cd040bd0f17fcd5242d"
+                "reference": "0525c73950de35ded110cffafb9892946d7771b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/06113cfdaf117fc2165f9cd040bd0f17fcd5242d",
-                "reference": "06113cfdaf117fc2165f9cd040bd0f17fcd5242d",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0525c73950de35ded110cffafb9892946d7771b5",
+                "reference": "0525c73950de35ded110cffafb9892946d7771b5",
                 "shasum": ""
             },
             "require": {
@@ -2809,7 +2809,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-09-15T11:28:58+00:00"
+            "time": "2025-11-10T16:43:36+00:00"
         },
         {
             "name": "symfony/config",


### PR DESCRIPTION
## Summary

- Upgrade PHPUnit from 9.6.29 to 11.5.43
- Migrate PHPUnit XML configuration to latest schema
- Convert all PHPUnit annotations to PHP 8 attributes
- Update Rector configuration with PHPUnit 11 support
- Update CI environment to PHP 8.4

## Changes

### Dependencies
- Update `composer.json`: `phpunit/phpunit` ^9.6.29 → ^11.0

### Test Modernization
- Convert `@depends` annotations to `#[Depends()]` attributes
- Convert `@dataProvider` annotations to `#[DataProvider()]` attributes  
- Convert class-level `@covers` to `#[CoversClass()]` attributes
- Remove method-level `@covers` annotations (coverage auto-detected)
- Make all data provider methods static (PHPUnit 11 requirement)

### Configuration Updates
- Migrate `phpunit.xml.dist` to PHPUnit 11 schema
- Add PHPUnit 11 rule set to `rector.php`
- Update `.scrutinizer.yml` to PHP 8.4 environment
- Fix `.gitignore` for `.phpunit.cache` directory

## Test Plan

- [x] All 282 tests passing
- [x] No deprecation warnings
- [x] Code style checks passing
- [x] Static analysis clean

## Summary by Sourcery

Upgrade PHPUnit from v9 to v11 and modernize the test suite and configuration

Enhancements:
- Migrate PHPUnit annotations (@depends, @dataProvider, @covers) to PHP 8 attributes and make data providers static
- Update Rector configuration to use the PHPUnit 11 rule set and raise code quality and coverage levels

Build:
- Bump phpunit/phpunit to ^11.0 and update related dependencies (ray/aop, ray/di, koriym/hal) in composer.json

CI:
- Migrate phpunit.xml.dist to the PHPUnit 11 schema and set the CI environment to PHP 8.4 in .scrutinizer.yml

Chores:
- Exclude the .phpunit.cache directory in .gitignore