### PR TITLE
Add Ray.InputQuery #[Input] attribute support for OPTIONS method

### DIFF
--- a/src/OptionsMethodRequest.php
+++ b/src/OptionsMethodRequest.php
@@ -7,7 +7,6 @@ namespace BEAR\Resource;
 use Ray\InputQuery\Attribute\Input;
 use ReflectionAttribute;
 use ReflectionClass;
-use ReflectionException;
 use ReflectionMethod;
 use ReflectionNamedType;
 use ReflectionParameter;
@@ -71,30 +70,11 @@ final class OptionsMethodRequest
         $expandedParamNames = [];
 
         foreach ($parameters as $parameter) {
-            // Check for #[Input] attribute with object type
-            $inputAttributes = $parameter->getAttributes(Input::class, ReflectionAttribute::IS_INSTANCEOF);
-            if ($inputAttributes) {
-                $inputResult = $this->expandInputParameter($parameter);
-                if ($inputResult !== null) {
-                    [$inputParamDoc, $inputRequired] = $inputResult;
-                    $expandedParameters += $inputParamDoc;
-                    $expandedRequired = [...$expandedRequired, ...$inputRequired];
-                    $expandedParamNames[] = $parameter->name;
-                    continue;
-                }
+            if ($this->processInputParameter($parameter, $expandedParameters, $expandedRequired, $expandedParamNames)) {
+                continue;
             }
 
-            $name = (string) $parameter->name;
-            if (isset($ins[$name])) {
-                $paramDoc[$name]['in'] = $ins[$parameter->name];
-            }
-
-            if (! isset($paramDoc[$parameter->name])) {
-                $paramDoc[$name] = [];
-            }
-
-            $paramDoc = $this->paramType($paramDoc, $parameter);
-            $paramDoc = $this->paramDefault($paramDoc, $parameter);
+            $this->processRegularParameter($parameter, $paramDoc, $ins);
         }
 
         // Merge expanded parameters with regular parameters
@@ -107,6 +87,61 @@ final class OptionsMethodRequest
         }
 
         return $this->setParamMetas($paramDoc, $required);
+    }
+
+    /**
+     * Process #[Input] parameter and accumulate expanded data
+     *
+     * @param ParametersMap $expandedParameters
+     * @param list<string>  $expandedRequired
+     * @param list<string>  $expandedParamNames
+     *
+     * @return bool True if parameter was processed as Input parameter
+     */
+    private function processInputParameter(
+        ReflectionParameter $parameter,
+        array &$expandedParameters,
+        array &$expandedRequired,
+        array &$expandedParamNames,
+    ): bool {
+        $inputAttributes = $parameter->getAttributes(Input::class, ReflectionAttribute::IS_INSTANCEOF);
+        if (! $inputAttributes) {
+            return false;
+        }
+
+        $inputResult = $this->expandInputParameter($parameter);
+        if ($inputResult === null) {
+            return false;
+        }
+
+        [$inputParamDoc, $inputRequired] = $inputResult;
+        $expandedParameters += $inputParamDoc;
+        $expandedRequired = [...$expandedRequired, ...$inputRequired];
+        $expandedParamNames[] = $parameter->name;
+
+        return true;
+    }
+
+    /**
+     * Process regular (non-Input) parameter
+     *
+     * @param ParametersMap $paramDoc
+     * @param InsMap        $ins
+     */
+    private function processRegularParameter(ReflectionParameter $parameter, array &$paramDoc, array $ins): void
+    {
+        $name = $parameter->name;
+
+        if (isset($ins[$name])) {
+            $paramDoc[$name]['in'] = $ins[$name];
+        }
+
+        if (! isset($paramDoc[$name])) {
+            $paramDoc[$name] = [];
+        }
+
+        $this->setParameterType($paramDoc, $parameter);
+        $this->setParameterDefault($paramDoc, $parameter);
     }
 
     /**
@@ -232,36 +267,34 @@ final class OptionsMethodRequest
     }
 
     /**
+     * Set parameter default value if available
+     *
      * @param ParametersMap $paramDoc
-     *
-     * @return ParametersMap
-     *
-     * @throws ReflectionException
      */
-    private function paramDefault(array $paramDoc, ReflectionParameter $parameter): array
+    private function setParameterDefault(array &$paramDoc, ReflectionParameter $parameter): void
     {
-        $hasDefault = $parameter->isDefaultValueAvailable() && $parameter->getDefaultValue() !== null;
-        if ($hasDefault) {
-            $default = $parameter->getDefaultValue();
-            $paramDoc[(string) $parameter->name]['default'] = is_array($default) ? '[]' : (string) $parameter->getDefaultValue(); // @phpstan-ignore-lines
+        if (! $parameter->isDefaultValueAvailable() || $parameter->getDefaultValue() === null) {
+            return;
         }
 
-        return $paramDoc;
+        $default = $parameter->getDefaultValue();
+        $paramDoc[$parameter->name]['default'] = is_array($default) ? '[]' : (string) $default;
     }
 
     /**
-     * @param ParametersMap $paramDoc
+     * Set parameter type from reflection
      *
-     * @return ParametersMap
+     * @param ParametersMap $paramDoc
      */
-    private function paramType(array $paramDoc, ReflectionParameter $parameter): array
+    private function setParameterType(array &$paramDoc, ReflectionParameter $parameter): void
     {
         $type = $this->getParameterType($parameter, $paramDoc, $parameter->name);
-        if (is_string($type)) {
-            $paramDoc[(string) $parameter->name]['type'] = $type; // override type parameter by reflection over phpdoc param type
+        if (! is_string($type)) {
+            return;
         }
 
-        return $paramDoc;
+        // Override type parameter by reflection over phpdoc param type
+        $paramDoc[$parameter->name]['type'] = $type;
     }
 
     private function getType(ReflectionParameter $parameter): string
@@ -285,11 +318,11 @@ final class OptionsMethodRequest
     private function setParamMetas(array $paramDoc, array $required): array
     {
         $paramMetas = [];
-        if ((bool) $paramDoc) {
+        if ($paramDoc !== []) {
             $paramMetas['parameters'] = $paramDoc;
         }
 
-        if ((bool) $required) {
+        if ($required !== []) {
             $paramMetas['required'] = $required;
         }
 

--- a/src/OptionsMethodRequest.php
+++ b/src/OptionsMethodRequest.php
@@ -13,7 +13,6 @@ use ReflectionNamedType;
 use ReflectionParameter;
 
 use function assert;
-use function class_exists;
 use function is_array;
 use function is_string;
 use function method_exists;
@@ -71,7 +70,7 @@ final class OptionsMethodRequest
             // Check for #[Input] attribute with object type
             $inputAttributes = $parameter->getAttributes(Input::class, ReflectionAttribute::IS_INSTANCEOF);
             if ($inputAttributes) {
-                $inputResult = $this->expandInputParameter($parameter, $ins);
+                $inputResult = $this->expandInputParameter($parameter);
                 if ($inputResult !== null) {
                     [$inputParamDoc, $inputRequired] = $inputResult;
                     $expandedParameters += $inputParamDoc;
@@ -108,11 +107,9 @@ final class OptionsMethodRequest
     /**
      * Expand #[Input] parameter to its constructor properties
      *
-     * @param InsMap $ins
-     *
      * @return array{0: ParametersMap, 1: RequiredParameterList}|null
      */
-    private function expandInputParameter(ReflectionParameter $parameter, array $ins): array|null
+    private function expandInputParameter(ReflectionParameter $parameter): array|null
     {
         $type = $parameter->getType();
         if (! $type instanceof ReflectionNamedType || $type->isBuiltin()) {
@@ -120,10 +117,6 @@ final class OptionsMethodRequest
         }
 
         $className = $type->getName();
-        if (! class_exists($className)) {
-            return null;
-        }
-
         $refClass = new ReflectionClass($className);
         $constructor = $refClass->getConstructor();
         if ($constructor === null) {
@@ -155,16 +148,11 @@ final class OptionsMethodRequest
             }
 
             // Check if required
-            if (! $ctorParam->isOptional()) {
-                $required[] = $name;
-            }
-
-            // Check for "in" mapping
-            if (! isset($ins[$name])) {
+            if ($ctorParam->isOptional()) {
                 continue;
             }
 
-            $paramDoc[$name]['in'] = $ins[$name];
+            $required[] = $name;
         }
 
         return [$paramDoc, $required];

--- a/src/OptionsMethodRequest.php
+++ b/src/OptionsMethodRequest.php
@@ -116,14 +116,7 @@ final class OptionsMethodRequest
      */
     private function expandInputParameter(ReflectionParameter $parameter): array|null
     {
-        $type = $parameter->getType();
-        if (! $type instanceof ReflectionNamedType || $type->isBuiltin()) {
-            return null;
-        }
-
-        $className = $type->getName();
-        $refClass = new ReflectionClass($className);
-        $constructor = $refClass->getConstructor();
+        $constructor = $this->getConstructor($parameter);
         if ($constructor === null) {
             return null;
         }
@@ -133,26 +126,8 @@ final class OptionsMethodRequest
 
         foreach ($constructor->getParameters() as $ctorParam) {
             $name = $ctorParam->getName();
-            $paramDoc[$name] = [];
+            $paramDoc[$name] = $this->buildConstructorParamDoc($ctorParam);
 
-            // Set type
-            $ctorType = $ctorParam->getType();
-            if ($ctorType instanceof ReflectionNamedType) {
-                $typeName = $ctorType->getName();
-                if ($typeName === 'int') {
-                    $typeName = 'integer';
-                }
-
-                $paramDoc[$name]['type'] = $typeName;
-            }
-
-            // Set default if available
-            if ($ctorParam->isDefaultValueAvailable() && $ctorParam->getDefaultValue() !== null) {
-                $default = $ctorParam->getDefaultValue();
-                $paramDoc[$name]['default'] = is_array($default) ? '[]' : (string) $default;
-            }
-
-            // Check if required
             if ($ctorParam->isOptional()) {
                 continue;
             }
@@ -161,6 +136,72 @@ final class OptionsMethodRequest
         }
 
         return [$paramDoc, $required];
+    }
+
+    /**
+     * Get constructor from parameter type if it's a class with constructor
+     */
+    private function getConstructor(ReflectionParameter $parameter): ReflectionMethod|null
+    {
+        $type = $parameter->getType();
+        if (! $type instanceof ReflectionNamedType || $type->isBuiltin()) {
+            return null;
+        }
+
+        $refClass = new ReflectionClass($type->getName());
+
+        return $refClass->getConstructor();
+    }
+
+    /**
+     * Build parameter documentation for a constructor parameter
+     *
+     * @return array<string, string>
+     */
+    private function buildConstructorParamDoc(ReflectionParameter $ctorParam): array
+    {
+        $doc = [];
+
+        $typeName = $this->getConstructorParamType($ctorParam);
+        if ($typeName !== null) {
+            $doc['type'] = $typeName;
+        }
+
+        $default = $this->getDefaultValueString($ctorParam);
+        if ($default !== null) {
+            $doc['default'] = $default;
+        }
+
+        return $doc;
+    }
+
+    /**
+     * Get type name from constructor parameter
+     */
+    private function getConstructorParamType(ReflectionParameter $ctorParam): string|null
+    {
+        $ctorType = $ctorParam->getType();
+        if (! $ctorType instanceof ReflectionNamedType) {
+            return null;
+        }
+
+        $typeName = $ctorType->getName();
+
+        return $typeName === 'int' ? 'integer' : $typeName;
+    }
+
+    /**
+     * Get default value as string representation
+     */
+    private function getDefaultValueString(ReflectionParameter $param): string|null
+    {
+        if (! $param->isDefaultValueAvailable() || $param->getDefaultValue() === null) {
+            return null;
+        }
+
+        $default = $param->getDefaultValue();
+
+        return is_array($default) ? '[]' : (string) $default;
     }
 
     /**

--- a/src/OptionsMethodRequest.php
+++ b/src/OptionsMethodRequest.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace BEAR\Resource;
 
+use Ray\InputQuery\Attribute\Input;
+use ReflectionAttribute;
+use ReflectionClass;
 use ReflectionException;
 use ReflectionMethod;
 use ReflectionNamedType;
 use ReflectionParameter;
 
 use function assert;
+use function class_exists;
 use function is_array;
 use function is_string;
 use function method_exists;
@@ -60,7 +64,22 @@ final class OptionsMethodRequest
      */
     private function getParamMetas(array $parameters, array $paramDoc, array $ins): array
     {
+        $expandedParameters = [];
+        $expandedRequired = [];
+
         foreach ($parameters as $parameter) {
+            // Check for #[Input] attribute with object type
+            $inputAttributes = $parameter->getAttributes(Input::class, ReflectionAttribute::IS_INSTANCEOF);
+            if ($inputAttributes) {
+                $inputResult = $this->expandInputParameter($parameter, $ins);
+                if ($inputResult !== null) {
+                    [$inputParamDoc, $inputRequired] = $inputResult;
+                    $expandedParameters += $inputParamDoc;
+                    $expandedRequired = [...$expandedRequired, ...$inputRequired];
+                    continue;
+                }
+            }
+
             $name = (string) $parameter->name;
             if (isset($ins[$name])) {
                 $paramDoc[$name]['in'] = $ins[$parameter->name];
@@ -74,9 +93,81 @@ final class OptionsMethodRequest
             $paramDoc = $this->paramDefault($paramDoc, $parameter);
         }
 
+        // Merge expanded parameters with regular parameters
+        $paramDoc = $expandedParameters + $paramDoc;
+
         $required = $this->getRequired($parameters);
+        // Replace required with expanded required if we have Input parameters
+        if ($expandedRequired !== []) {
+            $required = $expandedRequired;
+        }
 
         return $this->setParamMetas($paramDoc, $required);
+    }
+
+    /**
+     * Expand #[Input] parameter to its constructor properties
+     *
+     * @param InsMap $ins
+     *
+     * @return array{0: ParametersMap, 1: RequiredParameterList}|null
+     */
+    private function expandInputParameter(ReflectionParameter $parameter, array $ins): array|null
+    {
+        $type = $parameter->getType();
+        if (! $type instanceof ReflectionNamedType || $type->isBuiltin()) {
+            return null;
+        }
+
+        $className = $type->getName();
+        if (! class_exists($className)) {
+            return null;
+        }
+
+        $refClass = new ReflectionClass($className);
+        $constructor = $refClass->getConstructor();
+        if ($constructor === null) {
+            return null;
+        }
+
+        $paramDoc = [];
+        $required = [];
+
+        foreach ($constructor->getParameters() as $ctorParam) {
+            $name = $ctorParam->getName();
+            $paramDoc[$name] = [];
+
+            // Set type
+            $ctorType = $ctorParam->getType();
+            if ($ctorType instanceof ReflectionNamedType) {
+                $typeName = $ctorType->getName();
+                if ($typeName === 'int') {
+                    $typeName = 'integer';
+                }
+
+                $paramDoc[$name]['type'] = $typeName;
+            }
+
+            // Set default if available
+            if ($ctorParam->isDefaultValueAvailable() && $ctorParam->getDefaultValue() !== null) {
+                $default = $ctorParam->getDefaultValue();
+                $paramDoc[$name]['default'] = is_array($default) ? '[]' : (string) $default;
+            }
+
+            // Check if required
+            if (! $ctorParam->isOptional()) {
+                $required[] = $name;
+            }
+
+            // Check for "in" mapping
+            if (! isset($ins[$name])) {
+                continue;
+            }
+
+            $paramDoc[$name]['in'] = $ins[$name];
+        }
+
+        return [$paramDoc, $required];
     }
 
     /**

--- a/src/OptionsMethodRequest.php
+++ b/src/OptionsMethodRequest.php
@@ -12,7 +12,10 @@ use ReflectionMethod;
 use ReflectionNamedType;
 use ReflectionParameter;
 
+use function array_unique;
+use function array_values;
 use function assert;
+use function in_array;
 use function is_array;
 use function is_string;
 use function method_exists;
@@ -65,6 +68,7 @@ final class OptionsMethodRequest
     {
         $expandedParameters = [];
         $expandedRequired = [];
+        $expandedParamNames = [];
 
         foreach ($parameters as $parameter) {
             // Check for #[Input] attribute with object type
@@ -75,6 +79,7 @@ final class OptionsMethodRequest
                     [$inputParamDoc, $inputRequired] = $inputResult;
                     $expandedParameters += $inputParamDoc;
                     $expandedRequired = [...$expandedRequired, ...$inputRequired];
+                    $expandedParamNames[] = $parameter->name;
                     continue;
                 }
             }
@@ -95,10 +100,10 @@ final class OptionsMethodRequest
         // Merge expanded parameters with regular parameters
         $paramDoc = $expandedParameters + $paramDoc;
 
-        $required = $this->getRequired($parameters);
-        // Replace required with expanded required if we have Input parameters
+        $required = $this->getRequiredWithoutExpandedParams($parameters, $expandedParamNames);
+        // Merge expanded required with regular required
         if ($expandedRequired !== []) {
-            $required = $expandedRequired;
+            $required = array_values(array_unique([...$expandedRequired, ...$required]));
         }
 
         return $this->setParamMetas($paramDoc, $required);
@@ -159,15 +164,23 @@ final class OptionsMethodRequest
     }
 
     /**
+     * Get required parameters excluding successfully expanded #[Input] parameters
+     *
      * @param ReflectionParameterList $parameters
+     * @param list<string>            $expandedParamNames Names of parameters that were expanded
      *
      * @return RequiredParameterList
      */
-    private function getRequired(array $parameters): array
+    private function getRequiredWithoutExpandedParams(array $parameters, array $expandedParamNames): array
     {
         $required = [];
         foreach ($parameters as $parameter) {
             if ($parameter->isOptional()) {
+                continue;
+            }
+
+            // Skip parameters that were successfully expanded
+            if (in_array($parameter->name, $expandedParamNames, true)) {
                 continue;
             }
 

--- a/tests/Fake/InputNoConstructor.php
+++ b/tests/Fake/InputNoConstructor.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\Fake;
+
+final readonly class InputNoConstructor
+{
+    public string $name;
+}

--- a/tests/Fake/InputResourceBuiltinType.php
+++ b/tests/Fake/InputResourceBuiltinType.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\Fake;
+
+use BEAR\Resource\ResourceObject;
+use Ray\InputQuery\Attribute\Input;
+
+final class InputResourceBuiltinType extends ResourceObject
+{
+    public function onPost(#[Input] string $name): static
+    {
+        $this->body = ['name' => $name];
+
+        return $this;
+    }
+}

--- a/tests/Fake/InputResourceNoConstructor.php
+++ b/tests/Fake/InputResourceNoConstructor.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\Fake;
+
+use BEAR\Resource\ResourceObject;
+use Ray\InputQuery\Attribute\Input;
+
+final class InputResourceNoConstructor extends ResourceObject
+{
+    public function onPost(#[Input] InputNoConstructor $input): static
+    {
+        $this->body = [];
+
+        return $this;
+    }
+}

--- a/tests/Fake/InputResourceWithDefaults.php
+++ b/tests/Fake/InputResourceWithDefaults.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\Fake;
+
+use BEAR\Resource\ResourceObject;
+use Ray\InputQuery\Attribute\Input;
+
+final class InputResourceWithDefaults extends ResourceObject
+{
+    public function onPost(#[Input] InputWithDefaults $input): static
+    {
+        $this->body = [
+            'id' => $input->id,
+            'name' => $input->name,
+            'optional' => $input->optional,
+        ];
+
+        return $this;
+    }
+}

--- a/tests/Fake/InputResourceWithMixedParams.php
+++ b/tests/Fake/InputResourceWithMixedParams.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\Fake;
+
+use BEAR\Resource\ResourceObject;
+use Ray\InputQuery\Attribute\Input;
+
+final class InputResourceWithMixedParams extends ResourceObject
+{
+    public function onPost(#[Input] UserInput $user, string $token): static
+    {
+        $this->body = [
+            'name' => $user->name,
+            'email' => $user->email,
+            'token' => $token,
+        ];
+
+        return $this;
+    }
+}

--- a/tests/Fake/InputResourceWithUntyped.php
+++ b/tests/Fake/InputResourceWithUntyped.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\Fake;
+
+use BEAR\Resource\ResourceObject;
+use Ray\InputQuery\Attribute\Input;
+
+final class InputResourceWithUntyped extends ResourceObject
+{
+    public function onPost(#[Input] InputWithUntyped $input): static
+    {
+        $this->body = [
+            'name' => $input->name,
+            'untyped' => $input->untyped,
+        ];
+
+        return $this;
+    }
+}

--- a/tests/Fake/InputWithDefaults.php
+++ b/tests/Fake/InputWithDefaults.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\Fake;
+
+use Ray\InputQuery\Attribute\Input;
+
+final readonly class InputWithDefaults
+{
+    public function __construct(
+        #[Input] public int $id,
+        #[Input] public string $name = 'default',
+        #[Input] public ?string $optional = null,
+    ) {
+    }
+}

--- a/tests/Fake/InputWithUntyped.php
+++ b/tests/Fake/InputWithUntyped.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\Fake;
+
+use Ray\InputQuery\Attribute\Input;
+
+final class InputWithUntyped
+{
+    /** @var mixed */
+    public $untyped;
+
+    /** @param mixed $untyped */
+    public function __construct(
+        #[Input] public readonly string $name,
+        $untyped,
+    ) {
+        $this->untyped = $untyped;
+    }
+}

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BEAR\Resource;
 
+use BEAR\Resource\Fake\UserResource;
 use FakeVendor\Sandbox\Resource\App\DocInvalidFile;
 use FakeVendor\Sandbox\Resource\App\DocPhp7;
 use FakeVendor\Sandbox\Resource\App\DocUser;
@@ -271,5 +272,36 @@ class OptionsTest extends TestCase
 }
 ';
         $this->assertJsonStringEqualsJsonString($expected, (string) $ro->view);
+    }
+
+    public function testOptionsMethodWithInputAttribute(): void
+    {
+        $ro = new UserResource();
+        $request = new Request($this->invoker, $ro, Request::OPTIONS);
+        $this->invoker->invoke($request);
+        $actual = $ro->headers['Allow'];
+        $expected = 'POST';
+        $this->assertSame($actual, $expected);
+        $actual = (string) $ro->view;
+        $expected = '{
+    "POST": {
+        "request": {
+            "parameters": {
+                "name": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "email"
+            ]
+        }
+    }
+}
+';
+        $this->assertJsonStringEqualsJsonString($expected, $actual);
     }
 }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace BEAR\Resource;
 
+use BEAR\Resource\Fake\InputResourceBuiltinType;
+use BEAR\Resource\Fake\InputResourceNoConstructor;
+use BEAR\Resource\Fake\InputResourceWithDefaults;
 use BEAR\Resource\Fake\UserResource;
 use FakeVendor\Sandbox\Resource\App\DocInvalidFile;
 use FakeVendor\Sandbox\Resource\App\DocPhp7;
@@ -297,6 +300,94 @@ class OptionsTest extends TestCase
             "required": [
                 "name",
                 "email"
+            ]
+        }
+    }
+}
+';
+        $this->assertJsonStringEqualsJsonString($expected, $actual);
+    }
+
+    public function testOptionsMethodWithInputAttributeWithDefaults(): void
+    {
+        $ro = new InputResourceWithDefaults();
+        $request = new Request($this->invoker, $ro, Request::OPTIONS);
+        $this->invoker->invoke($request);
+        $actual = $ro->headers['Allow'];
+        $expected = 'POST';
+        $this->assertSame($actual, $expected);
+        $actual = (string) $ro->view;
+        $expected = '{
+    "POST": {
+        "request": {
+            "parameters": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string",
+                    "default": "default"
+                },
+                "optional": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id"
+            ]
+        }
+    }
+}
+';
+        $this->assertJsonStringEqualsJsonString($expected, $actual);
+    }
+
+    public function testOptionsMethodWithInputAttributeBuiltinType(): void
+    {
+        $ro = new InputResourceBuiltinType();
+        $request = new Request($this->invoker, $ro, Request::OPTIONS);
+        $this->invoker->invoke($request);
+        $actual = $ro->headers['Allow'];
+        $expected = 'POST';
+        $this->assertSame($actual, $expected);
+        $actual = (string) $ro->view;
+        $expected = '{
+    "POST": {
+        "request": {
+            "parameters": {
+                "name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ]
+        }
+    }
+}
+';
+        $this->assertJsonStringEqualsJsonString($expected, $actual);
+    }
+
+    public function testOptionsMethodWithInputAttributeNoConstructor(): void
+    {
+        $ro = new InputResourceNoConstructor();
+        $request = new Request($this->invoker, $ro, Request::OPTIONS);
+        $this->invoker->invoke($request);
+        $actual = $ro->headers['Allow'];
+        $expected = 'POST';
+        $this->assertSame($actual, $expected);
+        $actual = (string) $ro->view;
+        $expected = '{
+    "POST": {
+        "request": {
+            "parameters": {
+                "input": {
+                    "type": "BEAR\\\\Resource\\\\Fake\\\\InputNoConstructor"
+                }
+            },
+            "required": [
+                "input"
             ]
         }
     }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -7,6 +7,7 @@ namespace BEAR\Resource;
 use BEAR\Resource\Fake\InputResourceBuiltinType;
 use BEAR\Resource\Fake\InputResourceNoConstructor;
 use BEAR\Resource\Fake\InputResourceWithDefaults;
+use BEAR\Resource\Fake\InputResourceWithMixedParams;
 use BEAR\Resource\Fake\UserResource;
 use FakeVendor\Sandbox\Resource\App\DocInvalidFile;
 use FakeVendor\Sandbox\Resource\App\DocPhp7;
@@ -388,6 +389,41 @@ class OptionsTest extends TestCase
             },
             "required": [
                 "input"
+            ]
+        }
+    }
+}
+';
+        $this->assertJsonStringEqualsJsonString($expected, $actual);
+    }
+
+    public function testOptionsMethodWithInputAttributeMixedParams(): void
+    {
+        $ro = new InputResourceWithMixedParams();
+        $request = new Request($this->invoker, $ro, Request::OPTIONS);
+        $this->invoker->invoke($request);
+        $actual = $ro->headers['Allow'];
+        $expected = 'POST';
+        $this->assertSame($actual, $expected);
+        $actual = (string) $ro->view;
+        $expected = '{
+    "POST": {
+        "request": {
+            "parameters": {
+                "name": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "token": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "email",
+                "token"
             ]
         }
     }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -8,6 +8,7 @@ use BEAR\Resource\Fake\InputResourceBuiltinType;
 use BEAR\Resource\Fake\InputResourceNoConstructor;
 use BEAR\Resource\Fake\InputResourceWithDefaults;
 use BEAR\Resource\Fake\InputResourceWithMixedParams;
+use BEAR\Resource\Fake\InputResourceWithUntyped;
 use BEAR\Resource\Fake\UserResource;
 use FakeVendor\Sandbox\Resource\App\DocInvalidFile;
 use FakeVendor\Sandbox\Resource\App\DocPhp7;
@@ -424,6 +425,35 @@ class OptionsTest extends TestCase
                 "name",
                 "email",
                 "token"
+            ]
+        }
+    }
+}
+';
+        $this->assertJsonStringEqualsJsonString($expected, $actual);
+    }
+
+    public function testOptionsMethodWithInputAttributeUntyped(): void
+    {
+        $ro = new InputResourceWithUntyped();
+        $request = new Request($this->invoker, $ro, Request::OPTIONS);
+        $this->invoker->invoke($request);
+        $actual = $ro->headers['Allow'];
+        $expected = 'POST';
+        $this->assertSame($actual, $expected);
+        $actual = (string) $ro->view;
+        $expected = '{
+    "POST": {
+        "request": {
+            "parameters": {
+                "name": {
+                    "type": "string"
+                },
+                "untyped": []
+            },
+            "required": [
+                "name",
+                "untyped"
             ]
         }
     }


### PR DESCRIPTION
## Summary

- OPTIONSメソッドで`#[Input]`属性付きパラメータのコンストラクタプロパティを展開表示
- 展開されたプロパティの型、デフォルト値、必須パラメータを適切に表示

## Example

```php
class UserResource extends ResourceObject
{
    public function onPost(#[Input] UserInput $user): static { ... }
}

final readonly class UserInput
{
    public function __construct(
        #[Input] public string $name,
        #[Input] public string $email
    ) {}
}
```

OPTIONSレスポンス:

```json
{
    "POST": {
        "request": {
            "parameters": {
                "name": {"type": "string"},
                "email": {"type": "string"}
            },
            "required": ["name", "email"]
        }
    }
}
```

## Test plan

- [x] 新規テスト `testOptionsMethodWithInputAttribute` 追加
- [x] 既存のOptionsテストがすべてパス
- [x] `composer tests` がすべてパス

## Summary by Sourcery

Expand #[Input]-annotated object parameters into constructor properties in OPTIONS method metadata and cover the behavior with tests.

New Features:
- Support expansion of #[Input]-annotated object parameters into individual request parameters for OPTIONS responses, including type, default, and required flags.

Tests:
- Add OPTIONS method test for resources using #[Input]-annotated input objects to verify expanded parameters in the response.