### PR TITLE
Add Psalm taint annotations for security analysis

### DIFF
--- a/src/AbstractRequest.php
+++ b/src/AbstractRequest.php
@@ -120,7 +120,9 @@ abstract class AbstractRequest implements RequestInterface, ArrayAccess, Iterato
     /**
      * {@inheritDoc}
      *
-     * @param Query $query
+     * @param Query $query Query parameters that may contain user input
+     *
+     * @psalm-taint-source input $query
      */
     #[Override]
     public function __invoke(array|null $query = null): ResourceObject

--- a/src/AbstractUri.php
+++ b/src/AbstractUri.php
@@ -31,11 +31,7 @@ abstract class AbstractUri implements Stringable
     /** @var string */
     public $method = 'get';
 
-    /**
-     * @return string
-     *
-     * @psalm-taint-sink html
-     */
+    /** @return string */
     #[Override]
     public function __toString()
     {

--- a/src/AbstractUri.php
+++ b/src/AbstractUri.php
@@ -31,7 +31,11 @@ abstract class AbstractUri implements Stringable
     /** @var string */
     public $method = 'get';
 
-    /** @return string */
+    /**
+     * @return string
+     *
+     * @psalm-taint-specialize
+     */
     #[Override]
     public function __toString()
     {

--- a/src/AbstractUri.php
+++ b/src/AbstractUri.php
@@ -31,7 +31,11 @@ abstract class AbstractUri implements Stringable
     /** @var string */
     public $method = 'get';
 
-    /** @return string */
+    /**
+     * @return string
+     *
+     * @psalm-taint-sink html
+     */
     #[Override]
     public function __toString()
     {

--- a/src/AssistedWebContextParam.php
+++ b/src/AssistedWebContextParam.php
@@ -32,6 +32,8 @@ final class AssistedWebContextParam implements ParamInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @psalm-taint-source input
      */
     #[Override]
     public function __invoke(string $varName, array $query, InjectorInterface $injector)

--- a/src/HalRenderer.php
+++ b/src/HalRenderer.php
@@ -40,6 +40,8 @@ final readonly class HalRenderer implements RenderInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @psalm-taint-escape html
      */
     #[Override]
     public function render(ResourceObject $ro)

--- a/src/HttpRequestCurl.php
+++ b/src/HttpRequestCurl.php
@@ -47,7 +47,11 @@ final readonly class HttpRequestCurl implements HttpRequestInterface
     ) {
     }
 
-    /** @inheritDoc */
+    /**
+     * @inheritDoc
+     *
+     * @psalm-taint-sink ssrf $uri
+     */
     #[Override]
     public function request(string $method, string $uri, array $query): array
     {
@@ -70,6 +74,7 @@ final readonly class HttpRequestCurl implements HttpRequestInterface
         ];
     }
 
+    /** @psalm-taint-sink ssrf $uri */
     private function initializeCurl(string $method, string $uri, string $body): CurlHandle
     {
         $curl = curl_init();
@@ -116,7 +121,11 @@ final readonly class HttpRequestCurl implements HttpRequestInterface
         return $responseHeadersArray;
     }
 
-    /** @return HttpBody */
+    /**
+     * @return HttpBody
+     *
+     * @psalm-taint-source input
+     */
     private function parseBody(CurlHandle $curl, string $view): array
     {
         $responseBody = [];

--- a/src/HttpRequestCurl.php
+++ b/src/HttpRequestCurl.php
@@ -49,7 +49,6 @@ final readonly class HttpRequestCurl implements HttpRequestInterface
 
     /**
      * @inheritDoc
-     *
      * @psalm-taint-sink ssrf $uri
      */
     #[Override]

--- a/src/InputFormParam.php
+++ b/src/InputFormParam.php
@@ -37,6 +37,8 @@ final readonly class InputFormParam implements ParamInterface
      * Returns form metadata instead of parsing query data
      *
      * @param RequestQuery $query
+     *
+     * @psalm-taint-source input
      */
     #[Override]
     public function __invoke(string $varName, array $query, InjectorInterface $injector): AbstractFileUpload|null

--- a/src/InputFormsParam.php
+++ b/src/InputFormsParam.php
@@ -42,6 +42,8 @@ final readonly class InputFormsParam implements ParamInterface
      * @param RequestQuery $query
      *
      * @return array<AbstractFileUpload>
+     *
+     * @psalm-taint-source input
      */
     #[Override]
     public function __invoke(string $varName, array $query, InjectorInterface $injector): array

--- a/src/InputParam.php
+++ b/src/InputParam.php
@@ -27,6 +27,8 @@ final readonly class InputParam implements ParamInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @psalm-taint-source input
      */
     #[Override]
     public function __invoke(string $varName, array $query, InjectorInterface $injector)

--- a/src/JsonRenderer.php
+++ b/src/JsonRenderer.php
@@ -16,6 +16,8 @@ final class JsonRenderer implements RenderInterface
 {
     /**
      * {@inheritDoc}
+     *
+     * @psalm-taint-escape html
      */
     #[Override]
     public function render(ResourceObject $ro)

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -21,9 +21,11 @@ use const FILTER_VALIDATE_URL;
 final class Uri extends AbstractUri
 {
     /**
-     * @param Query $query
+     * @param Query $query Query parameters that may contain user input
      *
      * @throws UriException
+     *
+     * @psalm-taint-source input $query
      */
     public function __construct(
         string $uri,


### PR DESCRIPTION
## Summary

Add Psalm taint annotations to enable static security analysis for detecting:
- XSS vulnerabilities
- SSRF attacks
- SQL injection (when used with database modules)

## Changes

- `@psalm-taint-source input` on:
  - `AssistedWebContextParam::__invoke()` - Web context parameters
  - `InputParam::__invoke()` - Query parameters
  - `InputFormParam::__invoke()` - File uploads
  - `InputFormsParam::__invoke()` - Multiple file uploads
  - `Uri::__construct()` - URI query parameters
  - `AbstractRequest::__invoke()` - Request query parameters
  - `HttpRequestCurl::parseBody()` - External HTTP response body

- `@psalm-taint-sink ssrf` on:
  - `HttpRequestCurl::request()` - Prevents SSRF attacks
  - `HttpRequestCurl::initializeCurl()` - Internal curl initialization

- `@psalm-taint-escape html` on:
  - `JsonRenderer::render()` - JSON encoding escapes HTML
  - `HalRenderer::render()` - HAL+JSON encoding escapes HTML

## Test Plan

- [ ] Run `./vendor/bin/psalm --taint-analysis` to verify annotations work
- [ ] Existing tests pass