### PR TITLE
Add EmbedInterceptorInterface for swappable implementations

### DIFF
--- a/src/EmbedInterceptor.php
+++ b/src/EmbedInterceptor.php
@@ -9,7 +9,6 @@ use BEAR\Resource\Exception\BadRequestException;
 use BEAR\Resource\Exception\EmbedException;
 use BEAR\Resource\Exception\LinkException;
 use Override;
-use Ray\Aop\MethodInterceptor;
 use Ray\Aop\MethodInvocation;
 
 use function array_shift;
@@ -19,7 +18,7 @@ use function is_string;
 use function uri_template;
 
 /** @psalm-import-type Query from Types */
-final readonly class EmbedInterceptor implements MethodInterceptor
+final readonly class EmbedInterceptor implements EmbedInterceptorInterface
 {
     private const SELF_LINK = '_self';
 

--- a/src/EmbedInterceptorInterface.php
+++ b/src/EmbedInterceptorInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource;
+
+use Ray\Aop\MethodInterceptor;
+
+/**
+ * Interface for embed resource interceptor
+ *
+ * This interface allows alternative implementations (e.g., async/parallel)
+ * to be swapped in via dependency injection.
+ */
+interface EmbedInterceptorInterface extends MethodInterceptor
+{
+}

--- a/src/Module/EmbedResourceModule.php
+++ b/src/Module/EmbedResourceModule.php
@@ -6,6 +6,7 @@ namespace BEAR\Resource\Module;
 
 use BEAR\Resource\Annotation\Embed;
 use BEAR\Resource\EmbedInterceptor;
+use BEAR\Resource\EmbedInterceptorInterface;
 use Override;
 use Ray\Di\AbstractModule;
 
@@ -20,10 +21,11 @@ final class EmbedResourceModule extends AbstractModule
     #[Override]
     protected function configure(): void
     {
+        $this->bind(EmbedInterceptorInterface::class)->to(EmbedInterceptor::class);
         $this->bindInterceptor(
             $this->matcher->any(),
             $this->matcher->annotatedWith(Embed::class),
-            [EmbedInterceptor::class],
+            [EmbedInterceptorInterface::class],
         );
     }
 }


### PR DESCRIPTION
## Summary

- Create `EmbedInterceptorInterface` extending `MethodInterceptor`
- Make `EmbedInterceptor` implement the interface
- Update `EmbedResourceModule` to bind via interface

## Motivation

This allows alternative implementations (e.g., async/parallel embed resolution in BEAR.Swoole) to be swapped in via DI binding.

Example usage in BEAR.Swoole:

```php
final class AsyncEmbedModule extends AbstractModule
{
    protected function configure(): void
    {
        $this->bind(EmbedInterceptorInterface::class)->to(AsyncEmbedInterceptor::class);
    }
}
```