### PR TITLE
Optimize HalRenderer to reuse pre-rendered views

### DIFF
--- a/src/HalRenderer.php
+++ b/src/HalRenderer.php
@@ -95,7 +95,15 @@ final readonly class HalRenderer implements RenderInterface
 
             // @codeCoverageIgnoreEnd
             unset($ro->body[$key]);
-            $view = $this->render($embeded());
+            $embeddedRo = $embeded();
+            $isHalCached = is_string($embeddedRo->view)
+                && ($embeddedRo->headers['Content-Type'] ?? '') === 'application/hal+json';
+            if ($isHalCached) {
+                $ro->body['_embedded'][$key] = json_decode($embeddedRo->view, null, 512, JSON_THROW_ON_ERROR);
+                continue;
+            }
+
+            $view = $this->render($embeddedRo);
             $ro->body['_embedded'][$key] = json_decode($view, null, 512, JSON_THROW_ON_ERROR);
         }
     }


### PR DESCRIPTION
## Summary

- HalRenderer now reuses pre-rendered views from embedded resources instead of always re-rendering
- When parallel execution pre-caches views via `(string)$request`, those cached views are now utilized

## Changes

Modified `valuateElements()` to check if embedded resource already has a cached view before calling `render()`.

## Test plan

- [x] All existing tests pass (301 tests, 524 assertions)
- [x] Verified with xtrace that cached views are reused and `render()` is skipped when view exists

🤖 Generated with [Claude Code](https://claude.ai/code)