### PR TITLE
Validate JsonSchema input DTO arguments

### DIFF
--- a/src/JsonSchema/Interceptor/JsonSchemaInterceptor.php
+++ b/src/JsonSchema/Interceptor/JsonSchemaInterceptor.php
@@ -22,10 +22,8 @@ use Ray\InputQuery\Attribute\Input;
 use Ray\InputQuery\ToArray;
 use ReflectionAttribute;
 use ReflectionClass;
-use ReflectionParameter;
 use stdClass;
 
-use function array_replace;
 use function assert;
 use function file_exists;
 use function is_array;
@@ -223,14 +221,18 @@ final readonly class JsonSchemaInterceptor implements JsonSchemaInterceptorInter
     {
         $parameters = $invocation->getMethod()->getParameters();
         $values = $invocation->getArguments();
+        $toArray = new ToArray();
         /** @var Query $arguments */
         $arguments = [];
         foreach ($parameters as $index => $parameter) {
             /** @psalm-suppress MixedAssignment */
             $value = $values[$index] ?? $parameter->getDefaultValue();
-            $inputArguments = $this->getInputArguments($parameter, $value);
-            if ($inputArguments !== null) {
-                $arguments = array_replace($arguments, $inputArguments);
+            $inputAttributes = $parameter->getAttributes(Input::class, ReflectionAttribute::IS_INSTANCEOF);
+            if ($inputAttributes !== [] && is_object($value)) {
+                /** @psalm-suppress MixedAssignment */
+                foreach ($toArray($value) as $name => $inputValue) {
+                    $arguments[$name] = $inputValue;
+                }
 
                 continue;
             }
@@ -240,16 +242,5 @@ final readonly class JsonSchemaInterceptor implements JsonSchemaInterceptorInter
         }
 
         return $arguments;
-    }
-
-    /** @return Query|null */
-    private function getInputArguments(ReflectionParameter $parameter, mixed $value): array|null
-    {
-        $inputAttributes = $parameter->getAttributes(Input::class, ReflectionAttribute::IS_INSTANCEOF);
-        if ($inputAttributes === [] || ! is_object($value)) {
-            return null;
-        }
-
-        return (new ToArray())($value);
     }
 }

--- a/src/JsonSchema/Interceptor/JsonSchemaInterceptor.php
+++ b/src/JsonSchema/Interceptor/JsonSchemaInterceptor.php
@@ -18,9 +18,14 @@ use JsonSchema\Validator;
 use Override;
 use Ray\Aop\MethodInvocation;
 use Ray\Di\Di\Named;
+use Ray\InputQuery\Attribute\Input;
+use Ray\InputQuery\ToArray;
+use ReflectionAttribute;
 use ReflectionClass;
+use ReflectionParameter;
 use stdClass;
 
+use function array_replace;
 use function assert;
 use function file_exists;
 use function is_array;
@@ -218,12 +223,33 @@ final readonly class JsonSchemaInterceptor implements JsonSchemaInterceptorInter
     {
         $parameters = $invocation->getMethod()->getParameters();
         $values = $invocation->getArguments();
+        /** @var Query $arguments */
         $arguments = [];
         foreach ($parameters as $index => $parameter) {
             /** @psalm-suppress MixedAssignment */
-            $arguments[$parameter->name] = $values[$index] ?? $parameter->getDefaultValue();
+            $value = $values[$index] ?? $parameter->getDefaultValue();
+            $inputArguments = $this->getInputArguments($parameter, $value);
+            if ($inputArguments !== null) {
+                $arguments = array_replace($arguments, $inputArguments);
+
+                continue;
+            }
+
+            /** @psalm-suppress MixedAssignment */
+            $arguments[$parameter->name] = $value;
         }
 
         return $arguments;
+    }
+
+    /** @return Query|null */
+    private function getInputArguments(ReflectionParameter $parameter, mixed $value): array|null
+    {
+        $inputAttributes = $parameter->getAttributes(Input::class, ReflectionAttribute::IS_INSTANCEOF);
+        if ($inputAttributes === [] || ! is_object($value)) {
+            return null;
+        }
+
+        return (new ToArray())($value);
     }
 }

--- a/tests/Fake/JsonSchema/ArticleInput.php
+++ b/tests/Fake/JsonSchema/ArticleInput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\JsonSchema;
+
+use Ray\InputQuery\Attribute\Input;
+
+final readonly class ArticleInput
+{
+    public function __construct(
+        #[Input] public string $title,
+        #[Input] public string $slug,
+    ) {
+    }
+}

--- a/tests/Fake/JsonSchema/ArticleWithSeoInput.php
+++ b/tests/Fake/JsonSchema/ArticleWithSeoInput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\JsonSchema;
+
+use Ray\InputQuery\Attribute\Input;
+
+final readonly class ArticleWithSeoInput
+{
+    public function __construct(
+        #[Input] public string $title,
+        #[Input] public string $slug,
+        #[Input] public SeoInput $seo,
+    ) {
+    }
+}

--- a/tests/Fake/JsonSchema/FakeInputDtoResource.php
+++ b/tests/Fake/JsonSchema/FakeInputDtoResource.php
@@ -61,4 +61,17 @@ final class FakeInputDtoResource extends ResourceObject
 
         return $this;
     }
+
+    #[JsonSchema(params: 'input-dto.multiple.json')]
+    public function onOptions(#[Input] ArticleInput $article, #[Input] SeoInput $seo): static
+    {
+        $this->code = Code::NO_CONTENT;
+        $this->body = [
+            'metaTitle' => $seo->metaTitle,
+            'slug' => $article->slug,
+            'title' => $article->title,
+        ];
+
+        return $this;
+    }
 }

--- a/tests/Fake/JsonSchema/FakeInputDtoResource.php
+++ b/tests/Fake/JsonSchema/FakeInputDtoResource.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\JsonSchema;
+
+use BEAR\Resource\Annotation\JsonSchema;
+use BEAR\Resource\Code;
+use BEAR\Resource\ResourceObject;
+use Ray\InputQuery\Attribute\Input;
+
+final class FakeInputDtoResource extends ResourceObject
+{
+    #[JsonSchema(params: 'input-dto.single.json')]
+    public function onPost(#[Input] ArticleInput $input): static
+    {
+        $this->code = Code::NO_CONTENT;
+        $this->body = [
+            'slug' => $input->slug,
+            'title' => $input->title,
+        ];
+
+        return $this;
+    }
+
+    #[JsonSchema(params: 'input-dto.mixed.json')]
+    public function onPut(#[Input] ArticleInput $input, string $extra): static
+    {
+        $this->code = Code::NO_CONTENT;
+        $this->body = [
+            'extra' => $extra,
+            'slug' => $input->slug,
+            'title' => $input->title,
+        ];
+
+        return $this;
+    }
+
+    #[JsonSchema(params: 'input-dto.nested.json')]
+    public function onPatch(#[Input] ArticleWithSeoInput $input): static
+    {
+        $this->code = Code::NO_CONTENT;
+        $this->body = [
+            'metaTitle' => $input->seo->metaTitle,
+            'slug' => $input->slug,
+            'title' => $input->title,
+        ];
+
+        return $this;
+    }
+
+    #[JsonSchema(params: 'input-dto.optional.json')]
+    public function onDelete(
+        #[Input] OptionalArticleInput $input = new OptionalArticleInput('Default Title', 'default-title'),
+    ): static {
+        $this->code = Code::NO_CONTENT;
+        $this->body = [
+            'slug' => $input->slug,
+            'title' => $input->title,
+        ];
+
+        return $this;
+    }
+}

--- a/tests/Fake/JsonSchema/OptionalArticleInput.php
+++ b/tests/Fake/JsonSchema/OptionalArticleInput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\JsonSchema;
+
+use Ray\InputQuery\Attribute\Input;
+
+final readonly class OptionalArticleInput
+{
+    public function __construct(
+        #[Input] public string $title,
+        #[Input] public string $slug,
+    ) {
+    }
+}

--- a/tests/Fake/JsonSchema/SeoInput.php
+++ b/tests/Fake/JsonSchema/SeoInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\JsonSchema;
+
+use Ray\InputQuery\Attribute\Input;
+
+final readonly class SeoInput
+{
+    public function __construct(
+        #[Input] public string $metaTitle,
+    ) {
+    }
+}

--- a/tests/Fake/json_validate/input-dto.mixed.json
+++ b/tests/Fake/json_validate/input-dto.mixed.json
@@ -1,0 +1,17 @@
+{
+  "title": "Input DTO With Scalar",
+  "type": "object",
+  "properties": {
+    "extra": {
+      "type": "string"
+    },
+    "slug": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    }
+  },
+  "required": ["extra", "slug", "title"],
+  "additionalProperties": false
+}

--- a/tests/Fake/json_validate/input-dto.multiple.json
+++ b/tests/Fake/json_validate/input-dto.multiple.json
@@ -1,0 +1,17 @@
+{
+  "title": "Multiple Input DTO",
+  "type": "object",
+  "properties": {
+    "metaTitle": {
+      "type": "string"
+    },
+    "slug": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    }
+  },
+  "required": ["metaTitle", "slug", "title"],
+  "additionalProperties": false
+}

--- a/tests/Fake/json_validate/input-dto.nested.json
+++ b/tests/Fake/json_validate/input-dto.nested.json
@@ -1,0 +1,17 @@
+{
+  "title": "Nested Input DTO",
+  "type": "object",
+  "properties": {
+    "metaTitle": {
+      "type": "string"
+    },
+    "slug": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    }
+  },
+  "required": ["metaTitle", "slug", "title"],
+  "additionalProperties": false
+}

--- a/tests/Fake/json_validate/input-dto.optional.json
+++ b/tests/Fake/json_validate/input-dto.optional.json
@@ -1,0 +1,14 @@
+{
+  "title": "Optional Input DTO",
+  "type": "object",
+  "properties": {
+    "slug": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    }
+  },
+  "required": ["slug", "title"],
+  "additionalProperties": false
+}

--- a/tests/Fake/json_validate/input-dto.single.json
+++ b/tests/Fake/json_validate/input-dto.single.json
@@ -1,0 +1,14 @@
+{
+  "title": "Input DTO",
+  "type": "object",
+  "properties": {
+    "slug": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    }
+  },
+  "required": ["slug", "title"],
+  "additionalProperties": false
+}

--- a/tests/JsonSchema/Interceptor/JsonSchemaInterceptorTest.php
+++ b/tests/JsonSchema/Interceptor/JsonSchemaInterceptorTest.php
@@ -112,6 +112,13 @@ class JsonSchemaInterceptorTest extends TestCase
         $this->assertSame(['slug' => 'default-title', 'title' => 'Default Title'], $ro->body);
     }
 
+    public function testMultipleInputDtoParametersAreFlattenedForRequestValidation(): void
+    {
+        $ro = $this->invokeInputDtoResource('onOptions', [new ArticleInput('Hello', 'hello'), new SeoInput('Hello SEO')]);
+
+        $this->assertSame(['metaTitle' => 'Hello SEO', 'slug' => 'hello', 'title' => 'Hello'], $ro->body);
+    }
+
     /** @param list<mixed> $arguments */
     private function invokeInputDtoResource(string $method, array $arguments): ResourceObject
     {

--- a/tests/JsonSchema/Interceptor/JsonSchemaInterceptorTest.php
+++ b/tests/JsonSchema/Interceptor/JsonSchemaInterceptorTest.php
@@ -6,8 +6,12 @@ namespace BEAR\Resource\JsonSchema\Interceptor;
 
 use BEAR\Resource\Exception\JsonSchemaKeytNotFoundException;
 use BEAR\Resource\Interceptor\JsonSchemaInterceptor;
+use BEAR\Resource\JsonSchema\ArticleInput;
+use BEAR\Resource\JsonSchema\ArticleWithSeoInput;
+use BEAR\Resource\JsonSchema\FakeInputDtoResource;
 use BEAR\Resource\JsonSchema\FakeUser;
 use BEAR\Resource\JsonSchema\FakeView;
+use BEAR\Resource\JsonSchema\SeoInput;
 use BEAR\Resource\JsonSchemaExceptionNullHandler;
 use BEAR\Resource\JsonSchemaRequestExceptionNullHandler;
 use BEAR\Resource\ResourceObject;
@@ -75,5 +79,47 @@ class JsonSchemaInterceptorTest extends TestCase
         $invocation = new ReflectiveMethodInvocation($object, 'onGet', [20], $interceptrs);
         $ro = $this->jsonSchemaIntercetor->invoke($invocation);
         $this->assertInstanceOf(ResourceObject::class, $ro);
+    }
+
+    public function testInputDtoParameterIsFlattenedForRequestValidation(): void
+    {
+        $ro = $this->invokeInputDtoResource('onPost', [new ArticleInput('Hello', 'hello')]);
+
+        $this->assertSame(['slug' => 'hello', 'title' => 'Hello'], $ro->body);
+    }
+
+    public function testInputDtoParameterCanBeMixedWithScalarParameter(): void
+    {
+        $ro = $this->invokeInputDtoResource('onPut', [new ArticleInput('Hello', 'hello'), 'token']);
+
+        $this->assertSame(['extra' => 'token', 'slug' => 'hello', 'title' => 'Hello'], $ro->body);
+    }
+
+    public function testNestedInputDtoParameterIsFlattenedForRequestValidation(): void
+    {
+        $ro = $this->invokeInputDtoResource(
+            'onPatch',
+            [new ArticleWithSeoInput('Hello', 'hello', new SeoInput('Hello SEO'))],
+        );
+
+        $this->assertSame(['metaTitle' => 'Hello SEO', 'slug' => 'hello', 'title' => 'Hello'], $ro->body);
+    }
+
+    public function testOptionalInputDtoParameterDefaultIsFlattenedForRequestValidation(): void
+    {
+        $ro = $this->invokeInputDtoResource('onDelete', []);
+
+        $this->assertSame(['slug' => 'default-title', 'title' => 'Default Title'], $ro->body);
+    }
+
+    /** @param list<mixed> $arguments */
+    private function invokeInputDtoResource(string $method, array $arguments): ResourceObject
+    {
+        $object = new FakeInputDtoResource();
+        /** @var array<MethodInterceptor> $interceptrs */
+        $interceptrs = [$this->jsonSchemaIntercetor];
+        $invocation = new ReflectiveMethodInvocation($object, $method, $arguments, $interceptrs);
+
+        return $this->jsonSchemaIntercetor->invoke($invocation);
     }
 }


### PR DESCRIPTION
## Summary

- Flatten `#[Input]` DTO arguments before JsonSchema request validation
- Preserve existing non-`#[Input]` argument mapping behavior
- Add regression coverage for single DTO, mixed DTO/scalar, nested DTO, and optional default DTO cases

Closes #356

## Validation

- `composer test`
- `composer cs`
- `composer sa`
