### PR TITLE
Normalize input query parameter errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ray/aop": "^2.18.0",
         "ray/di": "^2.18.0",
         "rize/uri-template": "^0.4",
-        "ray/input-query": "^1.0",
+        "ray/input-query": "^1.1",
         "koriym/file-upload": "^1.0"
     },
     "require-dev": {

--- a/src/InputParam.php
+++ b/src/InputParam.php
@@ -28,6 +28,8 @@ final readonly class InputParam implements ParamInterface
     /**
      * {@inheritDoc}
      *
+     * @throws InvalidArgumentException When input query rejects request parameters or a required built-in parameter is missing.
+     *
      * @psalm-taint-source input
      */
     #[Override]

--- a/src/NamedParameter.php
+++ b/src/NamedParameter.php
@@ -33,8 +33,9 @@ final readonly class NamedParameter implements NamedParameterInterface
             try {
                 $parameters[$varName] = $param($varName, $query, $this->injector);
             } catch (InvalidArgumentException $e) {
-                // handle missing query parameter in Ray.InputQuery
-                throw new ParameterException($varName, $e->getCode(), $e);
+                $code = $e->getCode() !== 0 ? $e->getCode() : Code::BAD_REQUEST;
+
+                throw new ParameterException($varName, $code, $e);
             }
         }
 

--- a/tests/Fake/NativeArrayInput.php
+++ b/tests/Fake/NativeArrayInput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\Fake;
+
+use Ray\InputQuery\Attribute\Input;
+
+final readonly class NativeArrayInput
+{
+    /** @param list<int> $tagIds */
+    public function __construct(
+        #[Input]
+        public array $tagIds = [],
+    ) {
+    }
+}

--- a/tests/Fake/NativeArrayResource.php
+++ b/tests/Fake/NativeArrayResource.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\Fake;
+
+use BEAR\Resource\ResourceObject;
+use Ray\InputQuery\Attribute\Input;
+
+final class NativeArrayResource extends ResourceObject
+{
+    public function onPost(#[Input] NativeArrayInput $input): static
+    {
+        $this->body = [
+            'tagIds' => $input->tagIds,
+        ];
+
+        return $this;
+    }
+}

--- a/tests/Fake/NativeArrayResource.php
+++ b/tests/Fake/NativeArrayResource.php
@@ -17,4 +17,13 @@ final class NativeArrayResource extends ResourceObject
 
         return $this;
     }
+
+    public function onPut(#[Input] NullableNativeArrayInput $input): static
+    {
+        $this->body = [
+            'tagIds' => $input->tagIds,
+        ];
+
+        return $this;
+    }
 }

--- a/tests/Fake/NullableNativeArrayInput.php
+++ b/tests/Fake/NullableNativeArrayInput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\Fake;
+
+use Ray\InputQuery\Attribute\Input;
+
+final readonly class NullableNativeArrayInput
+{
+    /** @param list<int>|null $tagIds */
+    public function __construct(
+        #[Input]
+        public array|null $tagIds = null,
+    ) {
+    }
+}

--- a/tests/InputQueryIntegrationTest.php
+++ b/tests/InputQueryIntegrationTest.php
@@ -12,6 +12,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
 use Ray\InputQuery\Attribute\Input;
+use Ray\InputQuery\Exception\InvalidInputTypeException;
 use Ray\InputQuery\FileUploadFactory;
 use Ray\InputQuery\InputQuery;
 use Ray\InputQuery\InputQueryInterface;
@@ -90,6 +91,40 @@ class InputQueryIntegrationTest extends TestCase
         $ro = $resource->onPost(...$parameters);
 
         $this->assertSame(['tagIds' => [1, 2]], $ro->body);
+    }
+
+    public function testNativeArrayInputScalarValueThrowsParameterException(): void
+    {
+        $injector = new Injector();
+        $inputQuery = new InputQuery($injector, new FileUploadFactory());
+        $namedParamMetas = new NamedParamMetas($inputQuery, new FileUploadFactory());
+        $namedParameter = new NamedParameter($namedParamMetas, $injector);
+        $resource = new NativeArrayResource();
+
+        try {
+            $namedParameter->getParameters([$resource, 'onPost'], ['tagIds' => 1]);
+            $this->fail('Expected ParameterException for scalar native array input.');
+        } catch (ParameterException $e) {
+            $this->assertSame(Code::BAD_REQUEST, $e->getCode());
+            $this->assertInstanceOf(InvalidInputTypeException::class, $e->getPrevious());
+        }
+    }
+
+    public function testNullableNativeArrayInputScalarValueThrowsParameterException(): void
+    {
+        $injector = new Injector();
+        $inputQuery = new InputQuery($injector, new FileUploadFactory());
+        $namedParamMetas = new NamedParamMetas($inputQuery, new FileUploadFactory());
+        $namedParameter = new NamedParameter($namedParamMetas, $injector);
+        $resource = new NativeArrayResource();
+
+        try {
+            $namedParameter->getParameters([$resource, 'onPut'], ['tagIds' => 1]);
+            $this->fail('Expected ParameterException for scalar nullable native array input.');
+        } catch (ParameterException $e) {
+            $this->assertSame(Code::BAD_REQUEST, $e->getCode());
+            $this->assertInstanceOf(InvalidInputTypeException::class, $e->getPrevious());
+        }
     }
 
     public function testInputQueryInvalidArgumentThrowsParameterExceptionWithBadRequestCode(): void

--- a/tests/InputQueryIntegrationTest.php
+++ b/tests/InputQueryIntegrationTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace BEAR\Resource;
 
+use BEAR\Resource\Exception\ParameterException;
+use BEAR\Resource\Fake\NativeArrayResource;
 use BEAR\Resource\Fake\UserInput;
 use BEAR\Resource\Fake\UserResource;
 use InvalidArgumentException;
@@ -12,7 +14,9 @@ use Ray\Di\Injector;
 use Ray\InputQuery\Attribute\Input;
 use Ray\InputQuery\FileUploadFactory;
 use Ray\InputQuery\InputQuery;
+use Ray\InputQuery\InputQueryInterface;
 use ReflectionMethod;
+use TypeError;
 
 class InputQueryIntegrationTest extends TestCase
 {
@@ -72,6 +76,79 @@ class InputQueryIntegrationTest extends TestCase
         $this->assertInstanceOf(UserInput::class, $parameters['user']);
         $this->assertSame('Jane Smith', $parameters['user']->name);
         $this->assertSame('jane@example.com', $parameters['user']->email);
+    }
+
+    public function testNativeArrayInputEndToEndIntegration(): void
+    {
+        $injector = new Injector();
+        $inputQuery = new InputQuery($injector, new FileUploadFactory());
+        $namedParamMetas = new NamedParamMetas($inputQuery, new FileUploadFactory());
+        $namedParameter = new NamedParameter($namedParamMetas, $injector);
+        $resource = new NativeArrayResource();
+
+        $parameters = $namedParameter->getParameters([$resource, 'onPost'], ['tagIds' => [1, 2]]);
+        $ro = $resource->onPost(...$parameters);
+
+        $this->assertSame(['tagIds' => [1, 2]], $ro->body);
+    }
+
+    public function testInputQueryInvalidArgumentThrowsParameterExceptionWithBadRequestCode(): void
+    {
+        $injector = new Injector();
+        $inputQuery = new class implements InputQueryInterface {
+            public function getArguments(ReflectionMethod $method, array $query): array
+            {
+                unset($method, $query);
+
+                return [];
+            }
+
+            public function newInstance(string $class, array $query): object
+            {
+                unset($class, $query);
+
+                throw new InvalidArgumentException();
+            }
+        };
+        $namedParamMetas = new NamedParamMetas($inputQuery, new FileUploadFactory());
+        $namedParameter = new NamedParameter($namedParamMetas, $injector);
+        $resource = new NativeArrayResource();
+
+        try {
+            $namedParameter->getParameters([$resource, 'onPost'], ['tagIds' => 1]);
+            $this->fail('Expected ParameterException for invalid input query.');
+        } catch (ParameterException $e) {
+            $this->assertSame(Code::BAD_REQUEST, $e->getCode());
+            $this->assertInstanceOf(InvalidArgumentException::class, $e->getPrevious());
+        }
+    }
+
+    public function testNamedParameterPropagatesHydrationTypeError(): void
+    {
+        $injector = new Injector();
+        $inputQuery = new class implements InputQueryInterface {
+            public function getArguments(ReflectionMethod $method, array $query): array
+            {
+                unset($method, $query);
+
+                return [];
+            }
+
+            public function newInstance(string $class, array $query): object
+            {
+                unset($class, $query);
+
+                throw new TypeError('typed DTO hydration failed');
+            }
+        };
+        $namedParamMetas = new NamedParamMetas($inputQuery, new FileUploadFactory());
+        $namedParameter = new NamedParameter($namedParamMetas, $injector);
+        $resource = new NativeArrayResource();
+
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessage('typed DTO hydration failed');
+
+        $namedParameter->getParameters([$resource, 'onPost'], []);
     }
 
     public function testMissingRequiredParameterThrowsException(): void


### PR DESCRIPTION
## Summary

- require `ray/input-query:^1.1` so native array input validation is available at runtime
- preserve the `NamedParameter` boundary that wraps input-query `InvalidArgumentException` as `ParameterException`
- normalize code `0` input-query failures to `Code::BAD_REQUEST`
- add coverage for native `array` and `array|null` DTO fields accepting list input and rejecting scalar input as a 400-class parameter error

## Why

BEAR.Resource should allow DTO constructors to declare native array fields such as `array $tagIds` / `array|null $tagIds` while malformed scalar input is reported as a request parameter error instead of leaking raw PHP type errors.

## Dependency

- Requires `ray/input-query:^1.1` / Ray.InputQuery `1.1.0` for constructor-before-call native array container validation.

## Validation

- `PATH=/opt/homebrew/opt/php@8.5/bin:$PATH vendor/bin/phpunit tests/InputQueryIntegrationTest.php`
- `PATH=/opt/homebrew/opt/php@8.4/bin:$PATH composer tests`

Note: `composer tests` under PHP 8.5 currently crashes inside Psalm due PHP 8.5 `SplObjectStorage` deprecations. The PHPUnit and coding-standard portions run, and the full suite passes with PHP 8.4.
