### PR TITLE
Skip body schema validation for cached rendered responses

### DIFF
--- a/src/JsonSchema/Interceptor/JsonSchemaInterceptor.php
+++ b/src/JsonSchema/Interceptor/JsonSchemaInterceptor.php
@@ -44,6 +44,8 @@ use const JSON_THROW_ON_ERROR;
  */
 final readonly class JsonSchemaInterceptor implements JsonSchemaInterceptorInterface
 {
+    private const HEADER_ETAG = 'ETag';
+
     public function __construct(
         #[Named('json_schema_dir')]
         private string $schemaDir,
@@ -105,7 +107,10 @@ final readonly class JsonSchemaInterceptor implements JsonSchemaInterceptorInter
     {
         $schemaFile = $this->getSchemaFile($jsonSchema, $ro);
         try {
-            $this->validateRo($ro, $schemaFile, $jsonSchema);
+            if (! $this->isCachedRenderedBodyResponse($ro, $jsonSchema)) {
+                $this->validateRo($ro, $schemaFile, $jsonSchema);
+            }
+
             if (is_string($this->schemaHost)) {
                 $ro->headers['Link'] = sprintf('<%s%s>; rel="describedby"', $this->schemaHost, $jsonSchema->schema);
             }
@@ -122,6 +127,16 @@ final readonly class JsonSchemaInterceptor implements JsonSchemaInterceptorInter
         /** @var array<stdClass>|stdClass $target */
         $target = is_object($json) ? $this->getTarget($json, $jsonSchema) : $json;
         $this->validate($target, $schemaFile);
+    }
+
+    private function isCachedRenderedBodyResponse(ResourceObject $ro, JsonSchema $jsonSchema): bool
+    {
+        if ($jsonSchema->target !== 'body' || ! isset($ro->headers[self::HEADER_ETAG]) || ! is_string($ro->view)) {
+            return false;
+        }
+
+        // BEAR.QueryRepository restores cached rendered responses as headers/view only.
+        return $ro->body === null;
     }
 
     private function getTarget(object $json, JsonSchema $jsonSchema): mixed

--- a/tests/JsonSchema/Interceptor/JsonSchemaInterceptorTest.php
+++ b/tests/JsonSchema/Interceptor/JsonSchemaInterceptorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BEAR\Resource\JsonSchema\Interceptor;
 
+use BEAR\Resource\Exception\JsonSchemaException;
 use BEAR\Resource\Exception\JsonSchemaKeytNotFoundException;
 use BEAR\Resource\Interceptor\JsonSchemaInterceptor;
 use BEAR\Resource\JsonSchema\ArticleInput;
@@ -17,8 +18,10 @@ use BEAR\Resource\JsonSchemaRequestExceptionNullHandler;
 use BEAR\Resource\ResourceObject;
 use PHPUnit\Framework\TestCase;
 use Ray\Aop\MethodInterceptor;
+use Ray\Aop\MethodInvocation;
 use Ray\Aop\ReflectiveMethodInvocation;
 
+use function assert;
 use function dirname;
 
 class JsonSchemaInterceptorTest extends TestCase
@@ -81,6 +84,41 @@ class JsonSchemaInterceptorTest extends TestCase
         $this->assertInstanceOf(ResourceObject::class, $ro);
     }
 
+    public function testBodyValidationIsSkippedForCachedRenderedResponse(): void
+    {
+        $object = new FakeUser();
+        $invocation = new ReflectiveMethodInvocation($object, 'onGet', [20], [
+            $this->cachedRenderedResponse('{"name":{"firstName":"mucha","lastName":"alfons"},"age":20}'),
+        ]);
+
+        $ro = $this->jsonSchemaIntercetor->invoke($invocation);
+
+        $this->assertSame($object, $ro);
+        $this->assertSame('<http://example.com/schema/user.json>; rel="describedby"', $ro->headers['Link']);
+    }
+
+    public function testValidationRunsWhenBodyIsPresent(): void
+    {
+        $this->expectException(JsonSchemaException::class);
+        $object = new FakeUser();
+        $invocation = new ReflectiveMethodInvocation($object, 'onGet', [20], [
+            $this->cachedRenderedResponseWithBody('{"age":20}', ['age' => 20]),
+        ]);
+
+        $this->jsonSchemaIntercetor->invoke($invocation);
+    }
+
+    public function testViewValidationStillRunsForCachedRenderedResponse(): void
+    {
+        $this->expectException(JsonSchemaException::class);
+        $object = new FakeView();
+        $invocation = new ReflectiveMethodInvocation($object, 'onGet', [20], [
+            $this->cachedRenderedResponse('{"age":20}'),
+        ]);
+
+        $this->jsonSchemaIntercetor->invoke($invocation);
+    }
+
     public function testInputDtoParameterIsFlattenedForRequestValidation(): void
     {
         $ro = $this->invokeInputDtoResource('onPost', [new ArticleInput('Hello', 'hello')]);
@@ -128,5 +166,40 @@ class JsonSchemaInterceptorTest extends TestCase
         $invocation = new ReflectiveMethodInvocation($object, $method, $arguments, $interceptrs);
 
         return $this->jsonSchemaIntercetor->invoke($invocation);
+    }
+
+    private function cachedRenderedResponse(string $view): MethodInterceptor
+    {
+        return $this->renderedResponse($view);
+    }
+
+    private function cachedRenderedResponseWithBody(string $view, mixed $body): MethodInterceptor
+    {
+        return $this->renderedResponse($view, $body, true);
+    }
+
+    private function renderedResponse(string $view, mixed $body = null, bool $hasBody = false): MethodInterceptor
+    {
+        return new class ($view, $body, $hasBody) implements MethodInterceptor {
+            public function __construct(
+                private readonly string $view,
+                private readonly mixed $body,
+                private readonly bool $hasBody,
+            ) {
+            }
+
+            public function invoke(MethodInvocation $invocation): ResourceObject
+            {
+                $ro = $invocation->getThis();
+                assert($ro instanceof ResourceObject);
+                $ro->headers['ETag'] = '"cached"';
+                $ro->view = $this->view;
+                if ($this->hasBody) {
+                    $ro->body = $this->body;
+                }
+
+                return $ro;
+            }
+        };
     }
 }


### PR DESCRIPTION
## Summary
- Skip `JsonSchema(target: body)` response validation only for cached rendered responses where BEAR.QueryRepository restores `headers` and `view` without `body`.
- Keep normal body validation active when a body is present.
- Keep `target: view` validation active for cached rendered responses.

Fixes #355

## Notes
- The cached rendered response detection relies on the default `ResourceObject::$body === null` state. Resource classes should not override `$body` with a non-null default when they are expected to use this cache-hit path with body-target JSON Schema validation.

## Validation
- `PATH=/opt/homebrew/opt/php@8.5/bin:$PATH vendor/bin/phpunit tests/JsonSchema/Interceptor/JsonSchemaInterceptorTest.php`
- `PATH=/opt/homebrew/opt/php@8.5/bin:$PATH composer cs`
- `PATH=/opt/homebrew/opt/php@8.4/bin:$PATH composer tests`