### PR TITLE
Use (string) cast for embed evaluation in HalRenderer

### DIFF
--- a/src/AbstractRequest.php
+++ b/src/AbstractRequest.php
@@ -280,7 +280,7 @@ abstract class AbstractRequest implements RequestInterface, ArrayAccess, Iterato
     }
 
     #[Override]
-    public function jsonSerialize(): ResourceObject
+    public function jsonSerialize(): mixed
     {
         return $this->invoke();
     }

--- a/src/HalRenderer.php
+++ b/src/HalRenderer.php
@@ -73,6 +73,28 @@ final readonly class HalRenderer implements RenderInterface
     private function valuateElements(ResourceObject $ro): void
     {
         assert(is_array($ro->body));
+
+        // Pre-pass: seed every same-schema AbstractRequest embed with this
+        // renderer BEFORE any (string) cast. Lazy/batch decorators (e.g.
+        // BEAR.Async's AsyncRequest) flush the entire pending batch on the
+        // first __toString(), which renders embeds we have not visited yet
+        // in the loop below. Without this pre-pass those later embeds fall
+        // back to JsonRenderer and lose _links. For DI-wired resources this
+        // is a no-op since they already have HalRenderer bound via
+        // RenderInterface, but it also guards ad-hoc test construction
+        // where setter injection has not run.
+        foreach ($ro->body as $candidate) {
+            if (! ($candidate instanceof AbstractRequest)) {
+                continue;
+            }
+
+            if ($this->isDifferentSchema($ro, $candidate->resourceObject)) {
+                continue;
+            }
+
+            $candidate->resourceObject->setRenderer($this);
+        }
+
         /** @var mixed $embeded */
         foreach ($ro->body as $key => &$embeded) {
             if (! ($embeded instanceof AbstractRequest)) {
@@ -101,12 +123,9 @@ final readonly class HalRenderer implements RenderInterface
             // (e.g. BEAR.Async's AsyncRequest) get a chance to short-circuit
             // before the underlying resource is invoked. AbstractRequest's
             // own __toString() then drives evaluation and rendering of the
-            // result. We pre-seed the embed's resourceObject with this
-            // HalRenderer to guarantee HAL output even when setter injection
-            // has not run (e.g. ad-hoc test construction); for DI-wired
-            // resources this is a no-op since they already have HalRenderer
-            // bound via RenderInterface.
-            $embeded->resourceObject->setRenderer($this);
+            // result. The pre-pass above has already seeded every same-schema
+            // embed's renderer, so a batch flush triggered here still emits
+            // HAL for siblings we have not yet visited.
             $view = (string) $embeded;
             $ro->body['_embedded'][$key] = json_decode($view, null, 512, JSON_THROW_ON_ERROR);
         }

--- a/src/HalRenderer.php
+++ b/src/HalRenderer.php
@@ -77,16 +77,16 @@ final readonly class HalRenderer implements RenderInterface
         // Batch decorators (e.g. BEAR.Async's AsyncRequest) flush the whole
         // pending batch on the first __toString(), so siblings must already
         // have HalRenderer set or they fall back to JsonRenderer and lose _links.
-        foreach ($ro->body as $candidate) {
-            if (! ($candidate instanceof AbstractRequest)) {
+        foreach ($ro->body as $maybeRequest) {
+            if (! ($maybeRequest instanceof AbstractRequest)) {
                 continue;
             }
 
-            if ($this->isDifferentSchema($ro, $candidate->resourceObject)) {
+            if ($this->isDifferentSchema($ro, $maybeRequest->resourceObject)) {
                 continue;
             }
 
-            $candidate->resourceObject->setRenderer($this);
+            $maybeRequest->resourceObject->setRenderer($this);
         }
 
         /** @var mixed $embeded */

--- a/src/HalRenderer.php
+++ b/src/HalRenderer.php
@@ -102,7 +102,6 @@ final readonly class HalRenderer implements RenderInterface
 
             assert(is_array($ro->body['_embedded']));
             // @codeCoverageIgnoreStart
-            // Different-schema embeds bypass __toString() decorators.
             if ($this->isDifferentSchema($ro, $embeded->resourceObject)) {
                 $ro->body['_embedded'][$key] = $embeded()->body;
                 unset($ro->body[$key]);

--- a/src/HalRenderer.php
+++ b/src/HalRenderer.php
@@ -74,15 +74,9 @@ final readonly class HalRenderer implements RenderInterface
     {
         assert(is_array($ro->body));
 
-        // Pre-pass: seed every same-schema AbstractRequest embed with this
-        // renderer BEFORE any (string) cast. Lazy/batch decorators (e.g.
-        // BEAR.Async's AsyncRequest) flush the entire pending batch on the
-        // first __toString(), which renders embeds we have not visited yet
-        // in the loop below. Without this pre-pass those later embeds fall
-        // back to JsonRenderer and lose _links. For DI-wired resources this
-        // is a no-op since they already have HalRenderer bound via
-        // RenderInterface, but it also guards ad-hoc test construction
-        // where setter injection has not run.
+        // Batch decorators (e.g. BEAR.Async's AsyncRequest) flush the whole
+        // pending batch on the first __toString(), so siblings must already
+        // have HalRenderer set or they fall back to JsonRenderer and lose _links.
         foreach ($ro->body as $candidate) {
             if (! ($candidate instanceof AbstractRequest)) {
                 continue;
@@ -108,8 +102,7 @@ final readonly class HalRenderer implements RenderInterface
 
             assert(is_array($ro->body['_embedded']));
             // @codeCoverageIgnoreStart
-            // Different-schema embeds keep the existing direct __invoke() path,
-            // so decorators that flush in __toString() are not used here.
+            // Different-schema embeds bypass __toString() decorators.
             if ($this->isDifferentSchema($ro, $embeded->resourceObject)) {
                 $ro->body['_embedded'][$key] = $embeded()->body;
                 unset($ro->body[$key]);
@@ -119,13 +112,7 @@ final readonly class HalRenderer implements RenderInterface
 
             // @codeCoverageIgnoreEnd
             unset($ro->body[$key]);
-            // Render the embed via __toString() so that lazy/batch decorators
-            // (e.g. BEAR.Async's AsyncRequest) get a chance to short-circuit
-            // before the underlying resource is invoked. AbstractRequest's
-            // own __toString() then drives evaluation and rendering of the
-            // result. The pre-pass above has already seeded every same-schema
-            // embed's renderer, so a batch flush triggered here still emits
-            // HAL for siblings we have not yet visited.
+            // Use (string) so lazy decorators can short-circuit __invoke().
             $view = (string) $embeded;
             $ro->body['_embedded'][$key] = json_decode($view, null, 512, JSON_THROW_ON_ERROR);
         }

--- a/src/HalRenderer.php
+++ b/src/HalRenderer.php
@@ -86,6 +86,8 @@ final readonly class HalRenderer implements RenderInterface
 
             assert(is_array($ro->body['_embedded']));
             // @codeCoverageIgnoreStart
+            // Different-schema embeds keep the existing direct __invoke() path,
+            // so decorators that flush in __toString() are not used here.
             if ($this->isDifferentSchema($ro, $embeded->resourceObject)) {
                 $ro->body['_embedded'][$key] = $embeded()->body;
                 unset($ro->body[$key]);

--- a/src/HalRenderer.php
+++ b/src/HalRenderer.php
@@ -95,7 +95,17 @@ final readonly class HalRenderer implements RenderInterface
 
             // @codeCoverageIgnoreEnd
             unset($ro->body[$key]);
-            $view = $this->render($embeded());
+            // Render the embed via __toString() so that lazy/batch decorators
+            // (e.g. BEAR.Async's AsyncRequest) get a chance to short-circuit
+            // before the underlying resource is invoked. AbstractRequest's
+            // own __toString() then drives evaluation and rendering of the
+            // result. We pre-seed the embed's resourceObject with this
+            // HalRenderer to guarantee HAL output even when setter injection
+            // has not run (e.g. ad-hoc test construction); for DI-wired
+            // resources this is a no-op since they already have HalRenderer
+            // bound via RenderInterface.
+            $embeded->resourceObject->setRenderer($this);
+            $view = (string) $embeded;
             $ro->body['_embedded'][$key] = json_decode($view, null, 512, JSON_THROW_ON_ERROR);
         }
     }

--- a/src/HalRenderer.php
+++ b/src/HalRenderer.php
@@ -101,7 +101,6 @@ final readonly class HalRenderer implements RenderInterface
             }
 
             assert(is_array($ro->body['_embedded']));
-            // @codeCoverageIgnoreStart
             if ($this->isDifferentSchema($ro, $embeded->resourceObject)) {
                 $ro->body['_embedded'][$key] = $embeded()->body;
                 unset($ro->body[$key]);
@@ -109,7 +108,6 @@ final readonly class HalRenderer implements RenderInterface
                 continue;
             }
 
-            // @codeCoverageIgnoreEnd
             unset($ro->body[$key]);
             // Use (string) so lazy decorators can short-circuit __invoke().
             $view = (string) $embeded;
@@ -117,7 +115,6 @@ final readonly class HalRenderer implements RenderInterface
         }
     }
 
-    /** @codeCoverageIgnore */
     private function isDifferentSchema(ResourceObject $parentRo, ResourceObject $childRo): bool
     {
         return $parentRo->uri->scheme . $parentRo->uri->host !== $childRo->uri->scheme . $childRo->uri->host;

--- a/tests/Fake/FakeLazyInvoker.php
+++ b/tests/Fake/FakeLazyInvoker.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace BEAR\Resource;
 
+use BadMethodCallException;
 use Override;
-use RuntimeException;
 
 /**
  * Invoker that throws if reached. Used by FakeLazyRequest to assert that
@@ -17,7 +17,7 @@ final class FakeLazyInvoker implements InvokerInterface
     #[Override]
     public function invoke(AbstractRequest $request): ResourceObject
     {
-        throw new RuntimeException(
+        throw new BadMethodCallException(
             'FakeLazyInvoker::invoke() must not be called: a lazy decorator should short-circuit before invoke().',
         );
     }

--- a/tests/Fake/FakeLazyInvoker.php
+++ b/tests/Fake/FakeLazyInvoker.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource;
+
+use Override;
+use RuntimeException;
+
+/**
+ * Invoker that throws if reached. Used by FakeLazyRequest to assert that
+ * HalRenderer never invokes the underlying resource when its __toString()
+ * short-circuits (i.e. the lazy/batch decorator path).
+ */
+final class FakeLazyInvoker implements InvokerInterface
+{
+    #[Override]
+    public function invoke(AbstractRequest $request): ResourceObject
+    {
+        throw new RuntimeException(
+            'FakeLazyInvoker::invoke() must not be called: a lazy decorator should short-circuit before invoke().',
+        );
+    }
+}

--- a/tests/Fake/FakeLazyRequest.php
+++ b/tests/Fake/FakeLazyRequest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource;
+
+use LogicException;
+use Override;
+
+/**
+ * Simulates a lazy/batch decorator like bear/async's AsyncRequest:
+ * __toString() returns a pre-rendered JSON view without invoking the
+ * underlying resource at all. HalRenderer must drive evaluation via
+ * __toString() (i.e. (string) $request) so subclasses get a chance to
+ * hook in.
+ */
+final class FakeLazyRequest extends AbstractRequest
+{
+    private string $preRenderedView;
+
+    public function __construct(string $view, ResourceObject $resourceObject)
+    {
+        parent::__construct(new FakeLazyInvoker(), $resourceObject);
+        $this->preRenderedView = $view;
+    }
+
+    #[Override]
+    public function __toString(): string
+    {
+        // Note: we do NOT call $this->invoke(). The pre-rendered view stands
+        // in for whatever the lazy/batch decorator would emit. If HalRenderer
+        // bypassed __toString() (e.g. by calling $request() directly), the
+        // FakeLazyInvoker would throw and the test would fail.
+        return $this->preRenderedView;
+    }
+
+    #[Override]
+    public function withQuery(array $query): RequestInterface
+    {
+        throw new LogicException(__METHOD__);
+    }
+
+    #[Override]
+    public function addQuery(array $query): RequestInterface
+    {
+        throw new LogicException(__METHOD__);
+    }
+
+    #[Override]
+    public function toUri(): string
+    {
+        throw new LogicException(__METHOD__);
+    }
+
+    #[Override]
+    public function toUriWithMethod(): string
+    {
+        throw new LogicException(__METHOD__);
+    }
+
+    #[Override]
+    public function linkSelf(string $linkKey): RequestInterface
+    {
+        throw new LogicException(__METHOD__);
+    }
+
+    #[Override]
+    public function linkNew(string $linkKey): RequestInterface
+    {
+        throw new LogicException(__METHOD__);
+    }
+
+    #[Override]
+    public function linkCrawl(string $linkKey): RequestInterface
+    {
+        throw new LogicException(__METHOD__);
+    }
+}

--- a/tests/Fake/FakeLazyRequest.php
+++ b/tests/Fake/FakeLazyRequest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace BEAR\Resource;
 
-use LogicException;
+use BadMethodCallException;
 use Override;
 
 /**
@@ -37,42 +37,42 @@ final class FakeLazyRequest extends AbstractRequest
     #[Override]
     public function withQuery(array $query): RequestInterface
     {
-        throw new LogicException(__METHOD__);
+        throw new BadMethodCallException(__METHOD__);
     }
 
     #[Override]
     public function addQuery(array $query): RequestInterface
     {
-        throw new LogicException(__METHOD__);
+        throw new BadMethodCallException(__METHOD__);
     }
 
     #[Override]
     public function toUri(): string
     {
-        throw new LogicException(__METHOD__);
+        throw new BadMethodCallException(__METHOD__);
     }
 
     #[Override]
     public function toUriWithMethod(): string
     {
-        throw new LogicException(__METHOD__);
+        throw new BadMethodCallException(__METHOD__);
     }
 
     #[Override]
     public function linkSelf(string $linkKey): RequestInterface
     {
-        throw new LogicException(__METHOD__);
+        throw new BadMethodCallException(__METHOD__);
     }
 
     #[Override]
     public function linkNew(string $linkKey): RequestInterface
     {
-        throw new LogicException(__METHOD__);
+        throw new BadMethodCallException(__METHOD__);
     }
 
     #[Override]
     public function linkCrawl(string $linkKey): RequestInterface
     {
-        throw new LogicException(__METHOD__);
+        throw new BadMethodCallException(__METHOD__);
     }
 }

--- a/tests/Renderer/HalRendererTest.php
+++ b/tests/Renderer/HalRendererTest.php
@@ -9,7 +9,9 @@ use BEAR\Resource\FakeHal;
 use BEAR\Resource\FakeLazyRequest;
 use BEAR\Resource\HalLinker;
 use BEAR\Resource\HalRenderer;
+use BEAR\Resource\InvokerFactory;
 use BEAR\Resource\NullReverseLinker;
+use BEAR\Resource\Request;
 use BEAR\Resource\Uri;
 use PHPUnit\Framework\TestCase;
 
@@ -198,6 +200,26 @@ EOT;
         $this->assertSame(
             ['name' => 'stubbed'],
             (array) $this->ro->body['_embedded']['stub'],
+        );
+    }
+
+    public function testDifferentSchemaEmbedSkipsRendererPrePass(): void
+    {
+        $child = new FakeChild();
+        $child->uri = new Uri('page://self/bear/resource/fakechild');
+
+        $this->ro->body = [
+            'different' => new Request((new InvokerFactory())(), $child),
+        ];
+
+        $halRenderer = new HalRenderer(new HalLinker(new NullReverseLinker()));
+        $halRenderer->renderHal($this->ro);
+
+        $this->assertIsArray($this->ro->body);
+        $this->assertArrayHasKey('_embedded', $this->ro->body);
+        $this->assertSame(
+            ['tree' => 3],
+            $this->ro->body['_embedded']['different'],
         );
     }
 }

--- a/tests/Renderer/HalRendererTest.php
+++ b/tests/Renderer/HalRendererTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace BEAR\Resource\Renderer;
 
+use BEAR\Resource\FakeChild;
 use BEAR\Resource\FakeHal;
+use BEAR\Resource\FakeLazyRequest;
 use BEAR\Resource\HalLinker;
 use BEAR\Resource\HalRenderer;
 use BEAR\Resource\NullReverseLinker;
@@ -171,5 +173,31 @@ EOT;
         $actual = (string) $this->ro;
 
         $this->assertStringContainsString('"a": 1,', $actual);
+    }
+
+    /**
+     * Regression: HalRenderer must evaluate embedded AbstractRequest instances
+     * via __toString() so that lazy/batch decorators (e.g. bear/async's
+     * AsyncRequest) get a chance to short-circuit invoke(). FakeLazyRequest
+     * throws from its underlying invoker if invoke() is ever reached, so if
+     * the renderer bypassed __toString() this test would fail.
+     */
+    public function testEmbedEvaluationGoesThroughToString(): void
+    {
+        $child = new FakeChild();
+        $child->uri = new Uri('app://self/bear/resource/fakechild');
+        $lazy = new FakeLazyRequest('{"name": "stubbed"}', $child);
+
+        $this->ro->body = ['stub' => $lazy];
+
+        $halRenderer = new HalRenderer(new HalLinker(new NullReverseLinker()));
+        $halRenderer->renderHal($this->ro);
+
+        $this->assertIsArray($this->ro->body);
+        $this->assertArrayHasKey('_embedded', $this->ro->body);
+        $this->assertSame(
+            ['name' => 'stubbed'],
+            (array) $this->ro->body['_embedded']['stub'],
+        );
     }
 }


### PR DESCRIPTION
## Problem

`HalRenderer::valuateElements()` evaluates each embed via
`$view = $this->render($embeded());`. For plain `AbstractRequest` this is
fine, but for lazy subclasses (e.g. bear/async's `AsyncRequest` after it
extends `AbstractRequest`), the parallel batch only flushes when `__toString()`
is called.

`AbstractRequest::jsonSerialize()` also had a `ResourceObject` return type even
though PHP's `JsonSerializable::jsonSerialize()` contract is `mixed`. That
made lazy subclasses unable to return decoded batch results from
`jsonSerialize()` when `json_encode($ro)` reaches an embedded request during
JsonSchema validation.

## Fix

Replace with `$view = (string) $embeded;`. This is semantically equivalent
for plain `AbstractRequest` (its `__toString` already calls `invoke()` and
returns the rendered result) and enables lazy subclasses to flush their batch.

To keep behaviour identical when an embed has not been wired through DI
(e.g. ad-hoc test construction), the embed's `resourceObject` is pre-seeded
with the parent `HalRenderer` so the embed still renders as HAL rather than
falling back to `JsonRenderer`. For DI-wired resources this is a no-op since
they already have `HalRenderer` bound via `RenderInterface`.

`AbstractRequest::jsonSerialize()` is relaxed to `mixed` while keeping its
implementation unchanged (`return $this->invoke();`). Existing requests still
return a `ResourceObject`; lazy decorators can now override it with the actual
JSON-serializable value they need.

A regression test (`testEmbedEvaluationGoesThroughToString`) wires in a
`FakeLazyRequest` whose `__toString()` returns a pre-rendered string without
calling `invoke()`. Its invoker (`FakeLazyInvoker`) throws if reached, so any
code path that bypasses `__toString()` fails the test.

## Context

- Coordinated with bearsunday/BEAR.Async fix-hal-renderer-skip
- Tracking issue: bearsunday/BEAR.Async#18
- E2E verification: bearsunday/MyVendor.Cms#34

## Backward compatibility

For all current `AbstractRequest` callsites this is a pure refactor - no
observable behaviour change. The cross-schema branch (`$embeded()->body`)
is unchanged and remains a serial fallback.
