### PR TITLE
Handle PHP 8.5 HTTP and URI deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `HttpRequestException` for HTTP transport and response parsing failures
+
+### Changed
+- Set default cURL timeouts for HTTP resource requests: 5 seconds to connect and 30 seconds overall
+
 ## [1.31.2] - 2026-05-02
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "ray/aop": "^2.18.0",
         "ray/di": "^2.18.0",
-        "rize/uri-template": "^0.4",
+        "rize/uri-template": "^0.4.1",
         "ray/input-query": "^1.1",
         "koriym/file-upload": "^1.0"
     },

--- a/src/Exception/HttpRequestException.php
+++ b/src/Exception/HttpRequestException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\Exception;
+
+use BEAR\Resource\Code;
+use RuntimeException;
+use Throwable;
+
+final class HttpRequestException extends RuntimeException implements ExceptionInterface
+{
+    public function __construct(string $message = '', int $code = Code::ERROR, Throwable|null $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/HttpRequestCurl.php
+++ b/src/HttpRequestCurl.php
@@ -4,18 +4,21 @@ declare(strict_types=1);
 
 namespace BEAR\Resource;
 
+use BEAR\Resource\Exception\HttpRequestException;
 use CurlHandle;
+use JsonException;
 use Override;
-use RuntimeException;
 
 use function assert;
 use function count;
+use function curl_error;
 use function curl_exec;
 use function curl_getinfo;
 use function curl_init;
 use function curl_setopt;
 use function explode;
 use function http_build_query;
+use function is_string;
 use function json_decode;
 use function str_contains;
 use function strtolower;
@@ -25,12 +28,15 @@ use function trim;
 use const CURLINFO_CONTENT_TYPE;
 use const CURLINFO_HEADER_SIZE;
 use const CURLINFO_HTTP_CODE;
+use const CURLOPT_CONNECTTIMEOUT;
 use const CURLOPT_CUSTOMREQUEST;
 use const CURLOPT_HEADER;
 use const CURLOPT_HTTPHEADER;
 use const CURLOPT_POSTFIELDS;
 use const CURLOPT_RETURNTRANSFER;
+use const CURLOPT_TIMEOUT;
 use const CURLOPT_URL;
+use const JSON_THROW_ON_ERROR;
 
 /**
  * Sends a HTTP request using cURL
@@ -42,6 +48,9 @@ use const CURLOPT_URL;
  */
 final readonly class HttpRequestCurl implements HttpRequestInterface
 {
+    private const CONNECT_TIMEOUT_SECONDS = 5;
+    private const REQUEST_TIMEOUT_SECONDS = 30;
+
     public function __construct(
         private HttpRequestHeaders $requestHeaders,
     ) {
@@ -56,7 +65,11 @@ final readonly class HttpRequestCurl implements HttpRequestInterface
     {
         $body = http_build_query($query);
         $curl = $this->initializeCurl($method, $uri, $body);
-        $response = (string) curl_exec($curl);
+        $response = curl_exec($curl);
+        if (! is_string($response)) {
+            throw new HttpRequestException(curl_error($curl));
+        }
+
         $code = (int) curl_getinfo($curl, CURLINFO_HTTP_CODE);
         $headerSize = (int) curl_getinfo($curl, CURLINFO_HEADER_SIZE);
         $headerString = substr($response, 0, $headerSize);
@@ -78,13 +91,15 @@ final readonly class HttpRequestCurl implements HttpRequestInterface
     {
         $curl = curl_init();
         if ($curl === false) {
-            throw new RuntimeException('Failed to initialize cURL'); // @codeCoverageIgnore
+            throw new HttpRequestException('Failed to initialize cURL'); // @codeCoverageIgnore
         }
 
         assert($method !== '');
         assert($uri !== '');
         curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
         curl_setopt($curl, CURLOPT_URL, $uri);
+        curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, self::CONNECT_TIMEOUT_SECONDS);
+        curl_setopt($curl, CURLOPT_TIMEOUT, self::REQUEST_TIMEOUT_SECONDS);
 
         if ($this->requestHeaders->headers !== []) {
             curl_setopt($curl, CURLOPT_HTTPHEADER, $this->requestHeaders->headers);
@@ -130,7 +145,15 @@ final readonly class HttpRequestCurl implements HttpRequestInterface
         $responseBody = [];
         $contentType = (string) curl_getinfo($curl, CURLINFO_CONTENT_TYPE);
         if (str_contains(strtolower($contentType), 'application/json')) {
-            return (array) json_decode($view, true);
+            if ($view === '') {
+                return $responseBody;
+            }
+
+            try {
+                return (array) json_decode($view, true, 512, JSON_THROW_ON_ERROR);
+            } catch (JsonException $e) {
+                throw new HttpRequestException($e->getMessage(), Code::ERROR, $e);
+            }
         }
 
         return $responseBody;

--- a/src/ResourceObject.php
+++ b/src/ResourceObject.php
@@ -32,7 +32,7 @@ use const E_USER_WARNING;
 /**
  * @psalm-import-type Headers from Types
  * @psalm-import-type Body from Types
- * @phpstan-implements ArrayAccess<string, mixed>
+ * @phpstan-implements ArrayAccess<array-key, mixed>
  * @phpstan-implements IteratorAggregate<(int|string), mixed>
  */
 abstract class ResourceObject implements AcceptTransferInterface, ArrayAccess, Countable, IteratorAggregate, JsonSerializable, Stringable, InvokeRequestInterface
@@ -122,8 +122,8 @@ abstract class ResourceObject implements AcceptTransferInterface, ArrayAccess, C
     /**
      * Sets the body value at the specified index to renew
      *
-     * @param array-key $offset offset
-     * @param mixed     $value  value
+     * @param array-key|null $offset offset
+     * @param mixed          $value  value
      *
      * @return void
      */
@@ -137,6 +137,12 @@ abstract class ResourceObject implements AcceptTransferInterface, ArrayAccess, C
 
         if (! is_array($this->body)) {
             throw new IlligalAccessException((string) $offset);
+        }
+
+        if ($offset === null) {
+            $this->body[] = $value;
+
+            return;
         }
 
         $this->body[$offset] = $value;

--- a/tests/HttpRequestCurlTest.php
+++ b/tests/HttpRequestCurlTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource;
+
+use BEAR\Dev\Http\BuiltinServer;
+use BEAR\Resource\Exception\HttpRequestException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+use const PHP_OS_FAMILY;
+
+final class HttpRequestCurlTest extends TestCase
+{
+    private const HOST = '127.0.0.1:8101';
+    private const URL = 'http://127.0.0.1:8101/';
+
+    private static BuiltinServer $server;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$server = new BuiltinServer(self::HOST, __DIR__ . '/Server/http_request_curl.php');
+        self::$server->start();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        try {
+            self::$server->stop();
+        } catch (RuntimeException $e) {
+            if (PHP_OS_FAMILY !== 'Windows') {
+                throw $e;
+            }
+        }
+    }
+
+    public function testRequestFailureThrowsException(): void
+    {
+        $request = new HttpRequestCurl(new HttpRequestHeaders());
+
+        $this->expectException(HttpRequestException::class);
+
+        $request->request('GET', 'http://127.0.0.1:1/', []);
+    }
+
+    public function testJsonResponse(): void
+    {
+        $response = $this->request('valid');
+
+        $this->assertSame(200, $response['code']);
+        $this->assertSame(['ok' => true], $response['body']);
+        $this->assertSame('{"ok":true}', $response['view']);
+    }
+
+    public function testEmptyJsonResponse(): void
+    {
+        $response = $this->request('empty');
+
+        $this->assertSame(200, $response['code']);
+        $this->assertSame([], $response['body']);
+        $this->assertSame('', $response['view']);
+    }
+
+    public function testInvalidJsonResponseThrowsException(): void
+    {
+        $this->expectException(HttpRequestException::class);
+
+        $this->request('invalid');
+    }
+
+    /**
+     * @return array{
+     *     body: array<mixed>,
+     *     code: int,
+     *     headers: array<string, string>,
+     *     view: string
+     * }
+     */
+    private function request(string $case): array
+    {
+        $request = new HttpRequestCurl(new HttpRequestHeaders());
+
+        return $request->request('GET', self::URL . '?case=' . $case, []);
+    }
+}

--- a/tests/ObjectTest.php
+++ b/tests/ObjectTest.php
@@ -89,7 +89,6 @@ class ObjectTest extends TestCase
 
     public function testAppend(): void
     {
-        // @phpstan-ignore-next-line
         $this->ro[] = 'entry_append'; // same as $this->ro->boddy[] ='entry_append'
         assert(is_array($this->ro->body));
         $this->assertCount(4, $this->ro->body);

--- a/tests/Server/http_request_curl.php
+++ b/tests/Server/http_request_curl.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+$case = (string) ($_GET['case'] ?? 'valid');
+
+http_response_code(200);
+header('Content-Type: application/json; charset=utf-8');
+
+if ($case === 'empty') {
+    exit(0);
+}
+
+if ($case === 'invalid') {
+    echo '{';
+    exit(0);
+}
+
+echo '{"ok":true}';


### PR DESCRIPTION
## Summary
- Throw a domain-specific `HttpRequestException` when cURL execution fails or JSON response parsing fails.
- Handle `ResourceObject` array append offsets without triggering PHP 8.5 deprecations.
- Require `rize/uri-template` 0.4.1 to avoid PHP 8.5 default-operator deprecations.

## Validation
- `composer validate --strict --no-check-lock`
- `composer cs`
- `./vendor/bin/phpunit --display-deprecations`
- `./vendor-bin/tools/vendor/bin/phpstan --memory-limit=-1 analyse -c phpstan.neon --no-progress`
- `php -d error_reporting=24575 ./vendor-bin/tools/vendor/bin/phpmd --exclude src/Annotation src text ./phpmd.xml`