### PR TITLE
Remove invalid Request taint-source annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Set default cURL timeouts for HTTP resource requests: 5 seconds to connect and 30 seconds overall
 
+### Fixed
+- Remove invalid Psalm taint-source annotation from `AbstractRequest::__invoke()`
+
 ## [1.31.2] - 2026-05-02
 
 ### Fixed

--- a/src/AbstractRequest.php
+++ b/src/AbstractRequest.php
@@ -109,9 +109,7 @@ abstract class AbstractRequest implements RequestInterface, ArrayAccess, Iterato
     /**
      * {@inheritDoc}
      *
-     * @param Query $query Query parameters that may contain user input
-     *
-     * @psalm-taint-source input $query
+     * @param Query $query
      */
     #[Override]
     public function __invoke(array|null $query = null): ResourceObject


### PR DESCRIPTION
## Summary
- remove the invalid `@psalm-taint-source input $query` annotation from `AbstractRequest::__invoke()`
- document the correction in CHANGELOG

## Rationale
`@psalm-taint-source` marks a method return as a taint source. `AbstractRequest::__invoke()` accepts an internal query array and should not mark every invocation result as user input.

## Validation
- `zsh -ic 'sphp85; composer cs'`\n- `zsh -ic 'sphp85; composer test'`\n- `composer sa`\n- `zsh -ic 'sphp85; composer cs-fix'`