### PR TITLE
Distinguish request vs response source on JsonSchemaException (#369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `JsonSchemaError::$rawMessage` preserves the validator's original message,
   `$isCustomMessage` flags whether `$message` was overridden by the schema's
   ajv-errors-style `errorMessage`
-- `JsonSchemaRequestException` (Code::BAD_REQUEST, 400) and
-  `JsonSchemaResponseException` (Code::ERROR, 500) subclasses of
+- `JsonSchemaRequestException` and `JsonSchemaResponseException` subclasses of
   `JsonSchemaException` — request vs response validation failures are now
-  discriminable via `instanceof` at catch sites and carry semantic HTTP
-  status codes (#369)
+  discriminable via `instanceof` at catch sites. The interceptor throws them
+  with `Code::BAD_REQUEST` and `Code::ERROR` respectively; the codes are an
+  interceptor policy, not fixed by the exception class (#369)
 - Schema-side `errorMessage` overrides resolve through nested object/array
   schemas via JSON Pointer navigation (was: top-level only)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `JsonSchemaError::$rawMessage` preserves the validator's original message,
   `$isCustomMessage` flags whether `$message` was overridden by the schema's
   ajv-errors-style `errorMessage`
+- `JsonSchemaRequestException` (Code::BAD_REQUEST, 400) and
+  `JsonSchemaResponseException` (Code::ERROR, 500) subclasses of
+  `JsonSchemaException` — request vs response validation failures are now
+  discriminable via `instanceof` at catch sites and carry semantic HTTP
+  status codes (#369)
 - Schema-side `errorMessage` overrides resolve through nested object/array
   schemas via JSON Pointer navigation (was: top-level only)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,28 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `HttpRequestException` for HTTP transport and response parsing failures
-- `JsonSchemaException::getErrors()` now returns a structured `JsonSchemaErrors`
-  collection (`Countable`, `IteratorAggregate`, `hasErrors()`, `byProperty()`)
-  carrying typed `JsonSchemaError` / `ConstraintViolation` DTOs, so
-  `JsonSchemaRequestExceptionHandlerInterface` implementations can build
-  field-keyed error responses without re-running the validator (#364)
-- `JsonSchemaError::render(string $template)` interpolates `{key}` placeholders
-  against the error's data — supports ajv-errors-style `errorMessage` overrides
-- `JsonSchemaErrors::format(string $template = "{message}\n")` renders every
-  error through the template and concatenates the results
-- `JsonSchemaErrors::first()` returns the leading `JsonSchemaError` or null
-- `JsonSchemaError::$rawMessage` preserves the validator's original message,
-  `$isCustomMessage` flags whether `$message` was overridden by the schema's
-  ajv-errors-style `errorMessage`
-- `JsonSchemaRequestException` and `JsonSchemaResponseException` subclasses of
-  `JsonSchemaException` — request vs response validation failures are now
-  discriminable via `instanceof` at catch sites. Constructor `@param` is
-  narrowed to `ClientErrorCode = int<400, 499>` and `ServerErrorCode = int<500,
-  599>` respectively (declared in `BEAR\Resource\Types`), so callers are
-  statically constrained to a code in the right range. The interceptor uses
-  `Code::BAD_REQUEST` / `Code::ERROR` as sensible defaults (#369)
-- Schema-side `errorMessage` overrides resolve through nested object/array
-  schemas via JSON Pointer navigation (was: top-level only)
+- `JsonSchemaException::getErrors()` returning typed `JsonSchemaError` /
+  `ConstraintViolation` DTOs through a `JsonSchemaErrors` collection (#364)
+- `JsonSchemaRequestException` / `JsonSchemaResponseException` subclasses for
+  source discrimination at catch sites (#369)
 
 ### Changed
 - Set default cURL timeouts for HTTP resource requests: 5 seconds to connect and 30 seconds overall

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ajv-errors-style `errorMessage`
 - `JsonSchemaRequestException` and `JsonSchemaResponseException` subclasses of
   `JsonSchemaException` — request vs response validation failures are now
-  discriminable via `instanceof` at catch sites. The interceptor throws them
-  with `Code::BAD_REQUEST` and `Code::ERROR` respectively; the codes are an
-  interceptor policy, not fixed by the exception class (#369)
+  discriminable via `instanceof` at catch sites. Constructor `@param` is
+  narrowed to `ClientErrorCode = int<400, 499>` and `ServerErrorCode = int<500,
+  599>` respectively (declared in `BEAR\Resource\Types`), so callers are
+  statically constrained to a code in the right range. The interceptor uses
+  `Code::BAD_REQUEST` / `Code::ERROR` as sensible defaults (#369)
 - Schema-side `errorMessage` overrides resolve through nested object/array
   schemas via JSON Pointer navigation (was: top-level only)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -465,8 +465,8 @@ $errors->format("<li>{property}: {message}</li>\n");
 ```php
 try {
     $resource->get('app://self/user', ['id' => 'not-an-int']);
-} catch (JsonSchemaRequestException $e) {   // リクエスト検証失敗; @param int<400, 499>
-} catch (JsonSchemaResponseException $e) {  // レスポンス検証失敗; @param int<500, 599>
+} catch (JsonSchemaRequestException $e) {   // リクエスト検証失敗 (4xx)
+} catch (JsonSchemaResponseException $e) {  // レスポンス検証失敗 (5xx)
 }
 ```
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -465,12 +465,16 @@ $errors->format("<li>{property}: {message}</li>\n");
 `JsonSchemaException` には 2 つの concrete subclass があり、直接 catch する
 コードはクライアント由来の不正入力とリソース由来の不正出力を判別できます:
 
-- `JsonSchemaRequestException` — リクエストパラメータの検証失敗
-- `JsonSchemaResponseException` — レスポンスボディの検証失敗
+- `JsonSchemaRequestException` — リクエストパラメータの検証失敗。
+  コンストラクタの `@param` は `ClientErrorCode = int<400, 499>` に narrow
+  されているので、4xx 系の任意の code を渡せます。
+- `JsonSchemaResponseException` — レスポンスボディの検証失敗。
+  コンストラクタの `@param` は `ServerErrorCode = int<500, 599>` に narrow
+  されているので、5xx 系の任意の code を渡せます。
 
-interceptor はそれぞれを `Code::BAD_REQUEST` / `Code::ERROR` で throw しますが、
-code はあくまで interceptor 側のポリシーであり、例外クラスが固定するもの
-ではありません。
+interceptor はデフォルトとして `Code::BAD_REQUEST` / `Code::ERROR` を渡します。
+例外クラスが固定値を強制するわけではなく、code は caller の判断に委ねつつ
+レンジだけは型システムで保証する形です。
 
 ```php
 try {

--- a/README.ja.md
+++ b/README.ja.md
@@ -460,13 +460,36 @@ $errors->format("<li>{property}: {message}</li>\n");
 `$error->rawMessage` に保持されるので、ログやデバッグ用には rawMessage を
 使えます。
 
+### リクエスト・レスポンス由来の区別
+
+`JsonSchemaException` には 2 つの concrete subclass があり、直接 catch する
+コードはクライアント由来の不正入力とリソース由来の不正出力を判別できます:
+
+- `JsonSchemaRequestException` — リクエストパラメータの検証失敗
+  (`Code::BAD_REQUEST`, 400)
+- `JsonSchemaResponseException` — レスポンスボディの検証失敗
+  (`Code::ERROR`, 500)
+
+```php
+try {
+    $resource->get('app://self/user', ['id' => 'not-an-int']);
+} catch (JsonSchemaRequestException $e) {
+    // クライアント入力ミス → 4xx
+} catch (JsonSchemaResponseException $e) {
+    // リソースがスキーマ違反の出力をした → 5xx + アラート
+}
+```
+
+親 `JsonSchemaException` を catch すると両方マッチします。
+
 ### カスタムハンドラ
 
 独自の `JsonSchemaExceptionHandlerInterface` /
 `JsonSchemaRequestExceptionHandlerInterface` を束縛することで、検証失敗を
-422 レスポンスや構造化 JSON エラーボディに整形できます。ハンドラは
-`JsonSchemaException` を直接受け取るので、`$e->getErrors()` が構造化エラー情報の
-唯一の真実の情報源 (single source of truth) になります。
+422 レスポンスや構造化 JSON エラーボディに整形できます。ハンドラはそれぞれ
+の役割に対応する concrete subclass (`JsonSchemaResponseException` /
+`JsonSchemaRequestException`) を受け取るので、`$e->getErrors()` が構造化エラー
+情報の唯一の真実の情報源 (single source of truth) になります。
 
 ## 埋め込みリソース
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -466,17 +466,19 @@ $errors->format("<li>{property}: {message}</li>\n");
 コードはクライアント由来の不正入力とリソース由来の不正出力を判別できます:
 
 - `JsonSchemaRequestException` — リクエストパラメータの検証失敗
-  (`Code::BAD_REQUEST`, 400)
 - `JsonSchemaResponseException` — レスポンスボディの検証失敗
-  (`Code::ERROR`, 500)
+
+interceptor はそれぞれを `Code::BAD_REQUEST` / `Code::ERROR` で throw しますが、
+code はあくまで interceptor 側のポリシーであり、例外クラスが固定するもの
+ではありません。
 
 ```php
 try {
     $resource->get('app://self/user', ['id' => 'not-an-int']);
 } catch (JsonSchemaRequestException $e) {
-    // クライアント入力ミス → 4xx
+    // クライアント入力ミス
 } catch (JsonSchemaResponseException $e) {
-    // リソースがスキーマ違反の出力をした → 5xx + アラート
+    // リソースがスキーマ違反の出力をした
 }
 ```
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -460,7 +460,7 @@ $errors->format("<li>{property}: {message}</li>\n");
 `$error->rawMessage` に保持されるので、ログやデバッグ用には rawMessage を
 使えます。
 
-### リクエスト・レスポンス由来の区別
+### リクエスト/レスポンスの区別
 
 ```php
 try {

--- a/README.ja.md
+++ b/README.ja.md
@@ -462,31 +462,15 @@ $errors->format("<li>{property}: {message}</li>\n");
 
 ### リクエスト・レスポンス由来の区別
 
-`JsonSchemaException` には 2 つの concrete subclass があり、直接 catch する
-コードはクライアント由来の不正入力とリソース由来の不正出力を判別できます:
-
-- `JsonSchemaRequestException` — リクエストパラメータの検証失敗。
-  コンストラクタの `@param` は `ClientErrorCode = int<400, 499>` に narrow
-  されているので、4xx 系の任意の code を渡せます。
-- `JsonSchemaResponseException` — レスポンスボディの検証失敗。
-  コンストラクタの `@param` は `ServerErrorCode = int<500, 599>` に narrow
-  されているので、5xx 系の任意の code を渡せます。
-
-interceptor はデフォルトとして `Code::BAD_REQUEST` / `Code::ERROR` を渡します。
-例外クラスが固定値を強制するわけではなく、code は caller の判断に委ねつつ
-レンジだけは型システムで保証する形です。
-
 ```php
 try {
     $resource->get('app://self/user', ['id' => 'not-an-int']);
-} catch (JsonSchemaRequestException $e) {
-    // クライアント入力ミス
-} catch (JsonSchemaResponseException $e) {
-    // リソースがスキーマ違反の出力をした
+} catch (JsonSchemaRequestException $e) {   // リクエスト検証失敗; @param int<400, 499>
+} catch (JsonSchemaResponseException $e) {  // レスポンス検証失敗; @param int<500, 599>
 }
 ```
 
-親 `JsonSchemaException` を catch すると両方マッチします。
+どちらも `JsonSchemaException` のサブクラス — 親を catch すれば両方マッチ。
 
 ### カスタムハンドラ
 

--- a/README.md
+++ b/README.md
@@ -669,13 +669,38 @@ mapper renders it into `$error->message` automatically and sets
 `$error->rawMessage` so handlers can fall back to stable text for logs or
 debugging.
 
+### Request vs response source
+
+`JsonSchemaException` has two concrete subclasses so direct-catch code can
+discriminate between client-supplied bad input and a resource producing bad
+output:
+
+- `JsonSchemaRequestException` — request-parameter validation failed
+  (`Code::BAD_REQUEST`, 400)
+- `JsonSchemaResponseException` — response-body validation failed
+  (`Code::ERROR`, 500)
+
+```php
+try {
+    $resource->get('app://self/user', ['id' => 'not-an-int']);
+} catch (JsonSchemaRequestException $e) {
+    // bad client input → 4xx
+} catch (JsonSchemaResponseException $e) {
+    // our resource produced something off-schema → 5xx + alert
+}
+```
+
+Catching the parent `JsonSchemaException` still matches both.
+
 ### Custom handlers
 
 Bind your own `JsonSchemaExceptionHandlerInterface` /
 `JsonSchemaRequestExceptionHandlerInterface` to format the validation failure
-into a 422 response, structured JSON error body, etc. — the handler receives
-the `JsonSchemaException` directly, so `$e->getErrors()` is the single source
-of truth for the structured failure data.
+into a 422 response, structured JSON error body, etc. The handlers receive
+the concrete subclass that matches their role (`JsonSchemaResponseException`
+and `JsonSchemaRequestException`, respectively), so
+`$e->getErrors()` is the single source of truth for the structured failure
+data.
 
 ## Embedding resources
 

--- a/README.md
+++ b/README.md
@@ -671,33 +671,15 @@ debugging.
 
 ### Request vs response source
 
-`JsonSchemaException` has two concrete subclasses so direct-catch code can
-discriminate between client-supplied bad input and a resource producing bad
-output:
-
-- `JsonSchemaRequestException` — request-parameter validation failed.
-  Constructor `@param` is narrowed to `ClientErrorCode = int<400, 499>`,
-  so any 4xx is acceptable.
-- `JsonSchemaResponseException` — response-body validation failed.
-  Constructor `@param` is narrowed to `ServerErrorCode = int<500, 599>`,
-  so any 5xx is acceptable.
-
-The interceptor throws them with `Code::BAD_REQUEST` / `Code::ERROR` as
-sensible defaults. The exception class doesn't pin a specific code —
-the precise value is the caller's policy, statically constrained to
-the right range.
-
 ```php
 try {
     $resource->get('app://self/user', ['id' => 'not-an-int']);
-} catch (JsonSchemaRequestException $e) {
-    // bad client input
-} catch (JsonSchemaResponseException $e) {
-    // our resource produced something off-schema
+} catch (JsonSchemaRequestException $e) {   // request validation failed; @param int<400, 499>
+} catch (JsonSchemaResponseException $e) {  // response validation failed; @param int<500, 599>
 }
 ```
 
-Catching the parent `JsonSchemaException` still matches both.
+Both extend `JsonSchemaException` — catching the parent still matches both.
 
 ### Custom handlers
 

--- a/README.md
+++ b/README.md
@@ -675,12 +675,17 @@ debugging.
 discriminate between client-supplied bad input and a resource producing bad
 output:
 
-- `JsonSchemaRequestException` — request-parameter validation failed
-- `JsonSchemaResponseException` — response-body validation failed
+- `JsonSchemaRequestException` — request-parameter validation failed.
+  Constructor `@param` is narrowed to `ClientErrorCode = int<400, 499>`,
+  so any 4xx is acceptable.
+- `JsonSchemaResponseException` — response-body validation failed.
+  Constructor `@param` is narrowed to `ServerErrorCode = int<500, 599>`,
+  so any 5xx is acceptable.
 
-The interceptor throws them with `Code::BAD_REQUEST` and `Code::ERROR`
-respectively — the codes belong to the interceptor's policy, not to the
-exception class.
+The interceptor throws them with `Code::BAD_REQUEST` / `Code::ERROR` as
+sensible defaults. The exception class doesn't pin a specific code —
+the precise value is the caller's policy, statically constrained to
+the right range.
 
 ```php
 try {

--- a/README.md
+++ b/README.md
@@ -674,8 +674,8 @@ debugging.
 ```php
 try {
     $resource->get('app://self/user', ['id' => 'not-an-int']);
-} catch (JsonSchemaRequestException $e) {   // request validation failed; @param int<400, 499>
-} catch (JsonSchemaResponseException $e) {  // response validation failed; @param int<500, 599>
+} catch (JsonSchemaRequestException $e) {   // request validation failed (4xx)
+} catch (JsonSchemaResponseException $e) {  // response validation failed (5xx)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -676,17 +676,19 @@ discriminate between client-supplied bad input and a resource producing bad
 output:
 
 - `JsonSchemaRequestException` — request-parameter validation failed
-  (`Code::BAD_REQUEST`, 400)
 - `JsonSchemaResponseException` — response-body validation failed
-  (`Code::ERROR`, 500)
+
+The interceptor throws them with `Code::BAD_REQUEST` and `Code::ERROR`
+respectively — the codes belong to the interceptor's policy, not to the
+exception class.
 
 ```php
 try {
     $resource->get('app://self/user', ['id' => 'not-an-int']);
 } catch (JsonSchemaRequestException $e) {
-    // bad client input → 4xx
+    // bad client input
 } catch (JsonSchemaResponseException $e) {
-    // our resource produced something off-schema → 5xx + alert
+    // our resource produced something off-schema
 }
 ```
 

--- a/src/JsonSchema/Exception/JsonSchemaException.php
+++ b/src/JsonSchema/Exception/JsonSchemaException.php
@@ -7,7 +7,7 @@ namespace BEAR\Resource\Exception;
 use BEAR\Resource\JsonSchema\JsonSchemaErrors;
 use LogicException;
 
-final class JsonSchemaException extends LogicException implements ExceptionInterface
+class JsonSchemaException extends LogicException implements ExceptionInterface
 {
     private readonly JsonSchemaErrors $errors;
 

--- a/src/JsonSchema/Exception/JsonSchemaRequestException.php
+++ b/src/JsonSchema/Exception/JsonSchemaRequestException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\Exception;
+
+/**
+ * Thrown when a JSON Schema validation against a method's input parameters fails.
+ *
+ * Semantically a 4xx (client-supplied bad input). `JsonSchemaRequestExceptionHandlerInterface`
+ * receives this concrete subtype. Catching `JsonSchemaException` still matches.
+ */
+final class JsonSchemaRequestException extends JsonSchemaException
+{
+}

--- a/src/JsonSchema/Exception/JsonSchemaRequestException.php
+++ b/src/JsonSchema/Exception/JsonSchemaRequestException.php
@@ -4,12 +4,25 @@ declare(strict_types=1);
 
 namespace BEAR\Resource\Exception;
 
+use BEAR\Resource\Code;
+use BEAR\Resource\JsonSchema\JsonSchemaErrors;
+use BEAR\Resource\Types;
+
 /**
  * Thrown when a JSON Schema validation against a method's input parameters fails.
  *
- * Semantically a 4xx (client-supplied bad input). `JsonSchemaRequestExceptionHandlerInterface`
- * receives this concrete subtype. Catching `JsonSchemaException` still matches.
+ * Carries a 4xx-class `Code::*` value — the precise code (400, 401, 422, …) is the
+ * caller's policy. The narrowed `@param` enforces the range statically.
+ * `JsonSchemaRequestExceptionHandlerInterface` receives this concrete subtype;
+ * `catch (JsonSchemaException $e)` still matches.
+ *
+ * @psalm-import-type ClientErrorCode from Types
  */
 final class JsonSchemaRequestException extends JsonSchemaException
 {
+    /** @param ClientErrorCode $code */
+    public function __construct(string $message, int $code = Code::BAD_REQUEST, JsonSchemaErrors|null $errors = null)
+    {
+        parent::__construct($message, $code, $errors);
+    }
 }

--- a/src/JsonSchema/Exception/JsonSchemaResponseException.php
+++ b/src/JsonSchema/Exception/JsonSchemaResponseException.php
@@ -4,13 +4,25 @@ declare(strict_types=1);
 
 namespace BEAR\Resource\Exception;
 
+use BEAR\Resource\Code;
+use BEAR\Resource\JsonSchema\JsonSchemaErrors;
+use BEAR\Resource\Types;
+
 /**
  * Thrown when a JSON Schema validation against the resource's response body fails.
  *
- * Semantically a 5xx (the resource produced output that doesn't match its declared schema).
- * `JsonSchemaExceptionHandlerInterface` receives this concrete subtype. Catching
- * `JsonSchemaException` still matches.
+ * Carries a 5xx-class `Code::*` value — the precise code (500, 503, …) is the
+ * caller's policy. The narrowed `@param` enforces the range statically.
+ * `JsonSchemaExceptionHandlerInterface` receives this concrete subtype;
+ * `catch (JsonSchemaException $e)` still matches.
+ *
+ * @psalm-import-type ServerErrorCode from Types
  */
 final class JsonSchemaResponseException extends JsonSchemaException
 {
+    /** @param ServerErrorCode $code */
+    public function __construct(string $message, int $code = Code::ERROR, JsonSchemaErrors|null $errors = null)
+    {
+        parent::__construct($message, $code, $errors);
+    }
 }

--- a/src/JsonSchema/Exception/JsonSchemaResponseException.php
+++ b/src/JsonSchema/Exception/JsonSchemaResponseException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\Exception;
+
+/**
+ * Thrown when a JSON Schema validation against the resource's response body fails.
+ *
+ * Semantically a 5xx (the resource produced output that doesn't match its declared schema).
+ * `JsonSchemaExceptionHandlerInterface` receives this concrete subtype. Catching
+ * `JsonSchemaException` still matches.
+ */
+final class JsonSchemaResponseException extends JsonSchemaException
+{
+}

--- a/src/JsonSchema/Interceptor/JsonSchemaInterceptor.php
+++ b/src/JsonSchema/Interceptor/JsonSchemaInterceptor.php
@@ -160,7 +160,7 @@ final readonly class JsonSchemaInterceptor implements JsonSchemaInterceptorInter
     /** @param array<mixed>|stdClass $target */
     private function validateAsRequest(array|stdClass $target, string $schemaFile): void
     {
-        $validator = $this->runValidator($target, $schemaFile);
+        $validator = $this->validate($target, $schemaFile);
         if ($validator->isValid()) {
             return;
         }
@@ -173,7 +173,7 @@ final readonly class JsonSchemaInterceptor implements JsonSchemaInterceptorInter
     /** @param array<mixed>|stdClass $target */
     private function validateAsResponse(array|stdClass $target, string $schemaFile): void
     {
-        $validator = $this->runValidator($target, $schemaFile);
+        $validator = $this->validate($target, $schemaFile);
         if ($validator->isValid()) {
             return;
         }
@@ -184,7 +184,7 @@ final readonly class JsonSchemaInterceptor implements JsonSchemaInterceptorInter
     }
 
     /** @param array<mixed>|stdClass $target */
-    private function runValidator(array|stdClass $target, string $schemaFile): Validator
+    private function validate(array|stdClass $target, string $schemaFile): Validator
     {
         $validator = new Validator();
         $schema = (object) ['$ref' => 'file://' . $schemaFile];

--- a/src/JsonSchema/Interceptor/JsonSchemaInterceptor.php
+++ b/src/JsonSchema/Interceptor/JsonSchemaInterceptor.php
@@ -6,9 +6,10 @@ namespace BEAR\Resource\Interceptor;
 
 use BEAR\Resource\Annotation\JsonSchema;
 use BEAR\Resource\Code;
-use BEAR\Resource\Exception\JsonSchemaException;
 use BEAR\Resource\Exception\JsonSchemaKeytNotFoundException;
 use BEAR\Resource\Exception\JsonSchemaNotFoundException;
+use BEAR\Resource\Exception\JsonSchemaRequestException;
+use BEAR\Resource\Exception\JsonSchemaResponseException;
 use BEAR\Resource\JsonSchema\JsonSchemaErrorMapper;
 use BEAR\Resource\JsonSchema\JsonSchemaErrors;
 use BEAR\Resource\JsonSchemaExceptionHandlerInterface;
@@ -98,8 +99,8 @@ final readonly class JsonSchemaInterceptor implements JsonSchemaInterceptorInter
         try {
             $schemaFile = $this->validateDir . '/' . $jsonSchema->params;
             $this->validateFileExists($schemaFile);
-            $this->validate($arguments, $schemaFile);
-        } catch (JsonSchemaException $e) {
+            $this->validateAsRequest($arguments, $schemaFile);
+        } catch (JsonSchemaRequestException $e) {
             $ro = $invocation->getThis();
             assert($ro instanceof ResourceObject);
             /** @psalm-suppress PossiblyUndefinedVariable */
@@ -118,7 +119,7 @@ final readonly class JsonSchemaInterceptor implements JsonSchemaInterceptorInter
             if (is_string($this->schemaHost)) {
                 $ro->headers['Link'] = sprintf('<%s%s>; rel="describedby"', $this->schemaHost, $jsonSchema->schema);
             }
-        } catch (JsonSchemaException $e) {
+        } catch (JsonSchemaResponseException $e) {
             $this->handler->handle($ro, $e, $schemaFile);
         }
     }
@@ -130,7 +131,7 @@ final readonly class JsonSchemaInterceptor implements JsonSchemaInterceptorInter
         $json = json_decode($viewJson, null, 512, JSON_THROW_ON_ERROR);
         /** @var array<stdClass>|stdClass $target */
         $target = is_object($json) ? $this->getTarget($json, $jsonSchema) : $json;
-        $this->validate($target, $schemaFile);
+        $this->validateAsResponse($target, $schemaFile);
     }
 
     private function isCachedRenderedBodyResponse(ResourceObject $ro, JsonSchema $jsonSchema): bool
@@ -157,18 +158,40 @@ final readonly class JsonSchemaInterceptor implements JsonSchemaInterceptorInter
     }
 
     /** @param array<mixed>|stdClass $target */
-    private function validate(array|stdClass $target, string $schemaFile): void
+    private function validateAsRequest(array|stdClass $target, string $schemaFile): void
+    {
+        $validator = $this->runValidator($target, $schemaFile);
+        if ($validator->isValid()) {
+            return;
+        }
+
+        [$msg, $errors] = $this->buildValidationFailure($validator, $schemaFile);
+
+        throw new JsonSchemaRequestException($msg, Code::BAD_REQUEST, $errors);
+    }
+
+    /** @param array<mixed>|stdClass $target */
+    private function validateAsResponse(array|stdClass $target, string $schemaFile): void
+    {
+        $validator = $this->runValidator($target, $schemaFile);
+        if ($validator->isValid()) {
+            return;
+        }
+
+        [$msg, $errors] = $this->buildValidationFailure($validator, $schemaFile);
+
+        throw new JsonSchemaResponseException($msg, Code::ERROR, $errors);
+    }
+
+    /** @param array<mixed>|stdClass $target */
+    private function runValidator(array|stdClass $target, string $schemaFile): Validator
     {
         $validator = new Validator();
         $schema = (object) ['$ref' => 'file://' . $schemaFile];
         $scanArray = is_array($target) ? $target : $this->deepArray($target);
         $validator->validate($scanArray, $schema, Constraint::CHECK_MODE_TYPE_CAST);
-        $isValid = $validator->isValid();
-        if ($isValid) {
-            return;
-        }
 
-        throw $this->throwJsonSchemaException($validator, $schemaFile);
+        return $validator;
     }
 
     /** @return Body */
@@ -185,7 +208,8 @@ final readonly class JsonSchemaInterceptor implements JsonSchemaInterceptorInter
         return $result;
     }
 
-    private function throwJsonSchemaException(Validator $validator, string $schemaFile): JsonSchemaException
+    /** @return array{string, JsonSchemaErrors} */
+    private function buildValidationFailure(Validator $validator, string $schemaFile): array
     {
         /** @var JsonSchemaValidatorErrors $rawErrors */
         $rawErrors = $validator->getErrors();
@@ -201,7 +225,7 @@ final readonly class JsonSchemaInterceptor implements JsonSchemaInterceptorInter
 
         $msg .= "by {$schemaFile}";
 
-        return new JsonSchemaException($msg, Code::ERROR, new JsonSchemaErrors($structured));
+        return [$msg, new JsonSchemaErrors($structured)];
     }
 
     /**

--- a/src/JsonSchema/JsonSchemaExceptionHandlerInterface.php
+++ b/src/JsonSchema/JsonSchemaExceptionHandlerInterface.php
@@ -5,11 +5,18 @@ declare(strict_types=1);
 namespace BEAR\Resource;
 
 use BEAR\Resource\Exception\JsonSchemaException;
+use BEAR\Resource\Exception\JsonSchemaResponseException;
 
 interface JsonSchemaExceptionHandlerInterface
 {
     /**
      * Handle invalid JSON schema resource object
+     *
+     * The interceptor always delivers `JsonSchemaResponseException` (a subclass of
+     * `JsonSchemaException`) here. The runtime parameter type stays on the parent
+     * for backwards compatibility with existing implementations.
+     *
+     * @param JsonSchemaResponseException $e
      *
      * @return void
      */

--- a/src/JsonSchema/JsonSchemaRequestExceptionHandlerInterface.php
+++ b/src/JsonSchema/JsonSchemaRequestExceptionHandlerInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BEAR\Resource;
 
 use BEAR\Resource\Exception\JsonSchemaException;
+use BEAR\Resource\Exception\JsonSchemaRequestException;
 
 /** @psalm-import-type Query from Types */
 interface JsonSchemaRequestExceptionHandlerInterface
@@ -12,7 +13,12 @@ interface JsonSchemaRequestExceptionHandlerInterface
     /**
      * Handle invalid request object
      *
-     * @param Query $arguments
+     * The interceptor always delivers `JsonSchemaRequestException` (a subclass of
+     * `JsonSchemaException`) here. The runtime parameter type stays on the parent
+     * for backwards compatibility with existing implementations.
+     *
+     * @param Query                      $arguments
+     * @param JsonSchemaRequestException $e
      *
      * @return void
      */

--- a/src/Types.php
+++ b/src/Types.php
@@ -145,6 +145,10 @@ use ReflectionParameter;
  * }
  * @psalm-type JsonSchemaValidatorErrors = list<JsonSchemaValidatorError>
  *
+ * Resource Code Ranges
+ * @psalm-type ClientErrorCode = int<400, 499>
+ * @psalm-type ServerErrorCode = int<500, 599>
+ *
  * @phpcs:enable
  */
 final class Types

--- a/tests/JsonSchema/Exception/JsonSchemaRequestExceptionTest.php
+++ b/tests/JsonSchema/Exception/JsonSchemaRequestExceptionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\JsonSchema\Exception;
+
+use BEAR\Resource\Code;
+use BEAR\Resource\Exception\JsonSchemaException;
+use BEAR\Resource\Exception\JsonSchemaRequestException;
+use BEAR\Resource\JsonSchema\ConstraintViolation;
+use BEAR\Resource\JsonSchema\JsonSchemaError;
+use BEAR\Resource\JsonSchema\JsonSchemaErrors;
+use PHPUnit\Framework\TestCase;
+
+class JsonSchemaRequestExceptionTest extends TestCase
+{
+    public function testExtendsJsonSchemaException(): void
+    {
+        $e = new JsonSchemaRequestException('bad input', Code::BAD_REQUEST);
+
+        $this->assertInstanceOf(JsonSchemaException::class, $e);
+        $this->assertSame('bad input', $e->getMessage());
+        $this->assertSame(Code::BAD_REQUEST, $e->getCode());
+    }
+
+    public function testCarriesStructuredErrors(): void
+    {
+        $error = new JsonSchemaError('age', '/age', 'min', new ConstraintViolation('minimum', ['minimum' => 20]));
+        $e = new JsonSchemaRequestException('m', Code::BAD_REQUEST, new JsonSchemaErrors([$error]));
+
+        $this->assertCount(1, $e->getErrors());
+    }
+}

--- a/tests/JsonSchema/Exception/JsonSchemaResponseExceptionTest.php
+++ b/tests/JsonSchema/Exception/JsonSchemaResponseExceptionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Resource\JsonSchema\Exception;
+
+use BEAR\Resource\Code;
+use BEAR\Resource\Exception\JsonSchemaException;
+use BEAR\Resource\Exception\JsonSchemaResponseException;
+use BEAR\Resource\JsonSchema\ConstraintViolation;
+use BEAR\Resource\JsonSchema\JsonSchemaError;
+use BEAR\Resource\JsonSchema\JsonSchemaErrors;
+use PHPUnit\Framework\TestCase;
+
+class JsonSchemaResponseExceptionTest extends TestCase
+{
+    public function testExtendsJsonSchemaException(): void
+    {
+        $e = new JsonSchemaResponseException('bad output', Code::ERROR);
+
+        $this->assertInstanceOf(JsonSchemaException::class, $e);
+        $this->assertSame('bad output', $e->getMessage());
+        $this->assertSame(Code::ERROR, $e->getCode());
+    }
+
+    public function testCarriesStructuredErrors(): void
+    {
+        $error = new JsonSchemaError('age', '/age', 'min', new ConstraintViolation('minimum', ['minimum' => 20]));
+        $e = new JsonSchemaResponseException('m', Code::ERROR, new JsonSchemaErrors([$error]));
+
+        $this->assertCount(1, $e->getErrors());
+    }
+}

--- a/tests/Module/JsonSchemaModuleTest.php
+++ b/tests/Module/JsonSchemaModuleTest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace BEAR\Resource\Module;
 
+use BEAR\Resource\Code;
 use BEAR\Resource\Exception\JsonSchemaException;
 use BEAR\Resource\Exception\JsonSchemaNotFoundException;
+use BEAR\Resource\Exception\JsonSchemaRequestException;
+use BEAR\Resource\Exception\JsonSchemaResponseException;
 use BEAR\Resource\Interceptor\JsonSchemaInterceptorInterface;
 use BEAR\Resource\JsonSchema\ConstraintViolation;
 use BEAR\Resource\JsonSchema\FakePerson;
@@ -48,6 +51,32 @@ class JsonSchemaModuleTest extends TestCase
         $this->assertInstanceOf(JsonSchemaException::class, $e);
 
         return $e;
+    }
+
+    #[Depends('testValidateException')]
+    public function testResponseValidationThrowsResponseException(JsonSchemaException $e): void
+    {
+        // Response-body validation failure (resource returned data that doesn't match its schema)
+        // → 500 semantic. Subclass discriminates from request failures via `instanceof`.
+        $this->assertInstanceOf(JsonSchemaResponseException::class, $e);
+        $this->assertSame(Code::ERROR, $e->getCode());
+    }
+
+    public function testRequestValidationThrowsRequestException(): void
+    {
+        $ro = $this->getRo(FakeUser::class);
+        assert($ro instanceof FakeUser);
+        $caught = null;
+        try {
+            $ro->onGet(30, 'invalid gender');
+        } catch (JsonSchemaRequestException $e) {
+            $caught = $e;
+        }
+
+        $this->assertInstanceOf(JsonSchemaRequestException::class, $caught);
+        $this->assertSame(Code::BAD_REQUEST, $caught->getCode());
+        // BC: still catchable as the parent type.
+        $this->assertInstanceOf(JsonSchemaException::class, $caught);
     }
 
     public function testBCValidateException(): JsonSchemaException


### PR DESCRIPTION
Closes #369

> [!IMPORTANT]
> **Stacks on top of #367** — please merge #367 first. Until #367 lands, the diff against `1.x` will show #367's changes too. After #367 merges, this PR will rebase to only show #369.

cc @koriym

## Summary

Two concrete subclasses of `JsonSchemaException` let direct-catch code discriminate client-supplied bad input from off-schema output:

- `JsonSchemaRequestException` — request-parameter validation failed (`Code::BAD_REQUEST`, 400)
- `JsonSchemaResponseException` — response-body validation failed (`Code::ERROR`, 500)

```php
try {
    $resource->get('app://self/user', ['id' => 'not-an-int']);
} catch (JsonSchemaRequestException $e) {
    // bad client input → 4xx
} catch (JsonSchemaResponseException $e) {
    // off-schema output → 5xx + alert
}
```

## Design notes

- `final` dropped from the parent; nothing else about the parent changes. Existing `catch (JsonSchemaException $e)` still matches both subclasses — BC safe.
- Interceptor `validate()` split into `validateAsRequest()` / `validateAsResponse()`. Each throws its specific subclass directly — no `class-string` indirection or `if/else` over the target type.
- Shared logic in two helpers: `runValidator()` (justinrainbow invocation) + `buildValidationFailure()` returning `array{string, JsonSchemaErrors}` for the message + structured-error pair.
- Catch sites narrowed to the concrete subclass — no `assert($e instanceof ...)` needed. Safe because `JsonSchemaNotFoundException` extends `LogicException` directly, not `JsonSchemaException`, so it bubbles past the catch.
- Handler interface `@param` PHPDoc narrowed to the concrete subtype the interceptor actually delivers. Runtime parameter type stays on the parent for BC with existing implementations.

## Design history

The class-string approach was tried first (codex's initial pass). Switched to the split-method shape after review — codex itself agreed on the second pass: "split is cleaner, narrow catch is sound, two-helper split is natural".

## CI

- phpunit: 391 tests / 688 assertions (+6 from #367)
- phpcs (PSR-12 + Doctrine), phpstan max, psalm 7, phpmd — all clean locally
- 100% coverage on the touched interceptor + parent exception

## Test plan

- [x] `vendor/bin/phpunit`
- [x] `vendor/bin/phpcs --standard=phpcs.xml src tests`
- [x] `vendor/bin/phpstan --memory-limit=-1 analyse -c phpstan.neon`
- [x] `vendor/bin/psalm --monochrome --threads=1 --no-cache`
- [x] `vendor-bin/tools/vendor/bin/phpmd --exclude src/Annotation src text ./phpmd.xml`
- [ ] CI on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
