### PR TITLE
Update Psalm 7 tooling and cleanup tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,10 @@
 /composer.lock
 /.phpcs-cache
 /coverage.xml
+/coverage-pcov.xml
+/gh-pages/
 /tests/log/error.log
 /tests-php8/*
 /.phpunit.cache
 /CLAUDE.md
 /memo.txt
-

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    phpVersion="8.1"
+    phpVersion="8.2"
     errorLevel="1"
     runTaintAnalysis="false"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/tests/HttpResourceObjectTest.php
+++ b/tests/HttpResourceObjectTest.php
@@ -10,9 +10,12 @@ use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\AbstractModule;
 use Ray\Di\Injector;
+use RuntimeException;
 
 use function assert;
 use function is_array;
+
+use const PHP_OS_FAMILY;
 
 class HttpResourceObjectTest extends TestCase
 {
@@ -25,6 +28,17 @@ class HttpResourceObjectTest extends TestCase
     {
         self::$server = new BuiltinServer(self::HOST, __DIR__ . '/Server/index.php');
         self::$server->start();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        try {
+            self::$server->stop();
+        } catch (RuntimeException $e) {
+            if (PHP_OS_FAMILY !== 'Windows') {
+                throw $e;
+            }
+        }
     }
 
     protected function setUp(): void
@@ -95,7 +109,6 @@ class HttpResourceObjectTest extends TestCase
         $this->assertFalse($isSet);
     }
 
-    /** @notest */
     public function testHtmlResponse(): void
     {
         $module = new ResourceModule('FakeVendor\Sandbox');
@@ -108,8 +121,6 @@ class HttpResourceObjectTest extends TestCase
         $injector = new Injector($module, __DIR__ . '/tmp');
 
         $this->resource = $injector->getInstance(ResourceInterface::class);
-        self::$server = new BuiltinServer(self::HOST, __DIR__ . '/Server/index.php?media=html');
-        self::$server->start();
         $response = $this->resource->get(self::URL);
         $this->assertSame(200, $response->code);
         $this->assertSame('<html></html>', (string) $response->view);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,5 +3,16 @@
 declare(strict_types=1);
 
 require dirname(__DIR__) . '/vendor/autoload.php';
-array_map(unlink(...), (array) glob(__DIR__ . '/tmp/*.php')); // @phpstan-ignore-line
-array_map(unlink(...), (array) glob(__DIR__ . '/Module/tmp/{*.txt,*.php}', GLOB_BRACE));  // @phpstan-ignore-line
+
+$removeFiles = static function (string $pattern, int $flags = 0): void {
+    foreach ((array) glob($pattern, $flags) as $file) {
+        if (! is_file($file)) {
+            continue;
+        }
+
+        unlink($file);
+    }
+};
+
+$removeFiles(__DIR__ . '/tmp/*.php');
+$removeFiles(__DIR__ . '/Module/tmp/{*.txt,*.php}', GLOB_BRACE);

--- a/vendor-bin/require-checker/composer.json
+++ b/vendor-bin/require-checker/composer.json
@@ -1,4 +1,7 @@
 {
+    "name": "bear/resource-require-checker",
+    "description": "Composer require checker tools for BEAR.Resource",
+    "license": "MIT",
     "require-dev": {
         "maglnet/composer-require-checker": "^4.7"
     },

--- a/vendor-bin/require-checker/composer.lock
+++ b/vendor-bin/require-checker/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "323c104a86921dde3e1dd1ed97810849",
+    "content-hash": "23b0f5af1d339c3dc85b6b541a267556",
     "packages": [],
     "packages-dev": [
         {
@@ -990,5 +990,5 @@
     "platform-overrides": {
         "php": "8.1.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/vendor-bin/tools/composer.json
+++ b/vendor-bin/tools/composer.json
@@ -1,10 +1,13 @@
 {
+    "name": "bear/resource-tools",
+    "description": "Development tools for BEAR.Resource",
+    "license": "MIT",
     "require-dev": {
         "doctrine/coding-standard": "^14.0",
         "phpmd/phpmd": "^2.9",
         "phpstan/phpstan": "^2.1",
         "squizlabs/php_codesniffer": "^4.0",
-        "vimeo/psalm": "7.0.0-beta19"
+        "vimeo/psalm": "^7.0@beta"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/vendor-bin/tools/composer.lock
+++ b/vendor-bin/tools/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "acbe15ba5b2f530f5f382b22339275f5",
+    "content-hash": "b8ec331dbe3ad0c1f51772fb3b680968",
     "packages": [],
     "packages-dev": [
         {
@@ -2216,11 +2216,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.31",
+            "version": "2.2.1",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ead89849d879fe203ce9292c6ef5e7e76f867b96",
-                "reference": "ead89849d879fe203ce9292c6ef5e7e76f867b96",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dea9c8f2d25cc849391042b71e429c1a4bf82660",
+                "reference": "dea9c8f2d25cc849391042b71e429c1a4bf82660",
                 "shasum": ""
             },
             "require": {
@@ -2242,6 +2242,17 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
@@ -2265,7 +2276,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-10-10T14:14:11+00:00"
+            "time": "2026-05-28T14:44:12+00:00"
         },
         {
             "name": "psalm/psalm-plugin-api",
@@ -2957,16 +2968,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v8.0.11",
+            "version": "v8.0.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "3156577f46a38aa1b9323aad223de7a9cd426782"
+                "reference": "f200be111431cff4aeae8d086b91180bc4d7efd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/3156577f46a38aa1b9323aad223de7a9cd426782",
-                "reference": "3156577f46a38aa1b9323aad223de7a9cd426782",
+                "url": "https://api.github.com/repos/symfony/console/zipball/f200be111431cff4aeae8d086b91180bc4d7efd7",
+                "reference": "f200be111431cff4aeae8d086b91180bc4d7efd7",
                 "shasum": ""
             },
             "require": {
@@ -3023,7 +3034,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v8.0.11"
+                "source": "https://github.com/symfony/console/tree/v8.0.13"
             },
             "funding": [
                 {
@@ -3043,7 +3054,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-13T12:07:53+00:00"
+            "time": "2026-05-24T08:59:15+00:00"
         },
         {
             "name": "symfony/dependency-injection",
@@ -3355,16 +3366,16 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e"
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/4864388bfbd3001ce88e234fab652acd91fdc57e",
-                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
                 "shasum": ""
             },
             "require": {
@@ -3413,7 +3424,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -3433,20 +3444,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-26T13:13:48+00:00"
+            "time": "2026-05-26T05:58:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.37.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
                 "shasum": ""
             },
             "require": {
@@ -3498,7 +3509,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -3518,20 +3529,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-25T13:48:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
                 "shasum": ""
             },
             "require": {
@@ -3583,7 +3594,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -3603,20 +3614,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T17:25:58+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06"
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/88486db2c389b290bf87ff1de7ebc1e13e42bb06",
-                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
                 "shasum": ""
             },
             "require": {
@@ -3663,7 +3674,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -3683,7 +3694,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T18:47:49+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -3774,20 +3785,20 @@
         },
         {
             "name": "symfony/string",
-            "version": "v8.0.11",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "39be2ad058a3c0bd558edca23e65f009865d75ff"
+                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/39be2ad058a3c0bd558edca23e65f009865d75ff",
-                "reference": "39be2ad058a3c0bd558edca23e65f009865d75ff",
+                "url": "https://api.github.com/repos/symfony/string/zipball/afd5944f4005862d961efb85c8bbd5c523c4e3c9",
+                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
                 "symfony/polyfill-ctype": "^1.8",
                 "symfony/polyfill-intl-grapheme": "^1.33",
                 "symfony/polyfill-intl-normalizer": "^1.0",
@@ -3840,7 +3851,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v8.0.11"
+                "source": "https://github.com/symfony/string/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -3860,7 +3871,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-13T12:07:53+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/var-exporter",
@@ -4131,7 +4142,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": {
+        "vimeo/psalm": 10
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {},


### PR DESCRIPTION
## Summary

- Update the tools bin to track Psalm 7 via `^7.0@beta` and refresh the tools lockfile.
- Align Psalm analysis with the package PHP requirement by targeting PHP 8.2.
- Clean up test bootstrap file removal and HTTP test server lifecycle handling.
- Ignore generated `coverage-pcov.xml` and the separate `gh-pages/` checkout in the main repository.
- Add strict Composer metadata to bin composer manifests.

## Validation

- `composer cs-fix`
- `composer tests`
- `composer validate --strict --no-check-lock` (local ignored root `composer.lock` is stale)
- `composer bin tools validate --strict`
- `composer bin require-checker validate --strict`
- `composer bin tools audit --no-interaction`
- `composer bin require-checker audit --no-interaction`
- `composer bin tools outdated --direct --locked`
- `composer bin require-checker outdated --direct --locked`
- `git diff --check`
- `git merge-tree --write-tree upstream/1.x HEAD`
