### PR TITLE
Reach full branch coverage

### DIFF
--- a/src/JsonSchema/JsonSchemaErrors.php
+++ b/src/JsonSchema/JsonSchemaErrors.php
@@ -41,7 +41,9 @@ final readonly class JsonSchemaErrors implements Countable, IteratorAggregate
     /** @return Generator<int, JsonSchemaError> */
     public function getIterator(): Generator
     {
-        yield from $this->errors;
+        return (function (): Generator {
+            yield from $this->errors;
+        })();
     }
 
     /** First error if any, null on an empty collection. */

--- a/tests/JsonSchema/Interceptor/JsonSchemaInterceptorTest.php
+++ b/tests/JsonSchema/Interceptor/JsonSchemaInterceptorTest.php
@@ -26,6 +26,10 @@ use ReflectionMethod;
 use function assert;
 use function dirname;
 use function file_put_contents;
+use function is_string;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
 
 class JsonSchemaInterceptorTest extends TestCase
 {
@@ -140,12 +144,17 @@ class JsonSchemaInterceptorTest extends TestCase
 
     public function testNonObjectSchemaDecodeReturnsNull(): void
     {
-        $schemaFile = __DIR__ . '/../../tmp/non-object-schema.json';
+        $schemaFile = tempnam(sys_get_temp_dir(), 'non-object-schema-');
+        assert(is_string($schemaFile));
         file_put_contents($schemaFile, 'true');
 
-        $method = new ReflectionMethod(JsonSchemaInterceptor::class, 'schema');
+        try {
+            $method = new ReflectionMethod(JsonSchemaInterceptor::class, 'schema');
 
-        $this->assertNull($method->invoke($this->jsonSchemaIntercetor, $schemaFile));
+            $this->assertNull($method->invoke($this->jsonSchemaIntercetor, $schemaFile));
+        } finally {
+            unlink($schemaFile);
+        }
     }
 
     public function testInputDtoParameterIsFlattenedForRequestValidation(): void

--- a/tests/JsonSchema/Interceptor/JsonSchemaInterceptorTest.php
+++ b/tests/JsonSchema/Interceptor/JsonSchemaInterceptorTest.php
@@ -21,9 +21,11 @@ use PHPUnit\Framework\TestCase;
 use Ray\Aop\MethodInterceptor;
 use Ray\Aop\MethodInvocation;
 use Ray\Aop\ReflectiveMethodInvocation;
+use ReflectionMethod;
 
 use function assert;
 use function dirname;
+use function file_put_contents;
 
 class JsonSchemaInterceptorTest extends TestCase
 {
@@ -134,6 +136,16 @@ class JsonSchemaInterceptorTest extends TestCase
         $invocation = new ReflectiveMethodInvocation($object, 'onGet', [], $interceptrs);
 
         $this->jsonSchemaIntercetor->invoke($invocation);
+    }
+
+    public function testNonObjectSchemaDecodeReturnsNull(): void
+    {
+        $schemaFile = __DIR__ . '/../../tmp/non-object-schema.json';
+        file_put_contents($schemaFile, 'true');
+
+        $method = new ReflectionMethod(JsonSchemaInterceptor::class, 'schema');
+
+        $this->assertNull($method->invoke($this->jsonSchemaIntercetor, $schemaFile));
     }
 
     public function testInputDtoParameterIsFlattenedForRequestValidation(): void

--- a/tests/JsonSchema/JsonSchemaErrorMapperTest.php
+++ b/tests/JsonSchema/JsonSchemaErrorMapperTest.php
@@ -88,6 +88,20 @@ JSON));
         $this->assertSame('The property name is required', $error->rawMessage);
     }
 
+    public function testRequiredConstraintWithEmptyMissingPropertyFallsBackToRowProperty(): void
+    {
+        $row = [
+            'property' => 'fallback',
+            'pointer' => '',
+            'message' => 'The property is required',
+            'constraint' => ['name' => 'required', 'params' => ['property' => '']],
+        ];
+
+        $error = (new JsonSchemaErrorMapper())->toJsonSchemaError($row);
+
+        $this->assertSame('fallback', $error->property);
+    }
+
     public function testMapsJustinrainbow5xStringConstraintShape(): void
     {
         // In justinrainbow 5.x, `constraint` is a string and per-keyword params

--- a/tests/JsonSchema/JsonSchemaErrorTest.php
+++ b/tests/JsonSchema/JsonSchemaErrorTest.php
@@ -101,14 +101,15 @@ class JsonSchemaErrorTest extends TestCase
                 'expected' => 'integer',
                 'count' => 3,
                 'enabled' => true,
+                'disabled' => false,
                 'missing' => null,
                 'allowed' => ['a', 'b'],
             ]),
         );
 
         $this->assertSame(
-            'integer 3 true null ["a","b"]',
-            $error->render('{expected} {count} {enabled} {missing} {allowed}'),
+            'integer 3 true false null ["a","b"]',
+            $error->render('{expected} {count} {enabled} {disabled} {missing} {allowed}'),
         );
     }
 }

--- a/tests/JsonSchema/JsonSchemaErrorsTest.php
+++ b/tests/JsonSchema/JsonSchemaErrorsTest.php
@@ -44,6 +44,13 @@ class JsonSchemaErrorsTest extends TestCase
         $this->assertSame([$a, $b], iterator_to_array($errors));
     }
 
+    public function testGetIteratorCanBeConsumedDirectly(): void
+    {
+        $error = new JsonSchemaError('name', '/name', 'is required', new ConstraintViolation('required', []));
+
+        $this->assertSame([$error], iterator_to_array((new JsonSchemaErrors([$error]))->getIterator()));
+    }
+
     public function testByPropertyGroupsErrors(): void
     {
         $first = new JsonSchemaError('age', '/age', 'minimum is 20', new ConstraintViolation('minimum', []));

--- a/tests/JsonSchema/SchemaErrorMessageResolverTest.php
+++ b/tests/JsonSchema/SchemaErrorMessageResolverTest.php
@@ -74,6 +74,13 @@ class SchemaErrorMessageResolverTest extends TestCase
         $this->assertSame('Name required', $this->resolver->resolve($schema, $error));
     }
 
+    public function testRequiredMessagePerPropertyIgnoresNonStringMessage(): void
+    {
+        $error = $this->error('', 'required', 'name');
+        $schema = $this->schema('{"errorMessage": {"required": {"name": 42}}, "properties": {"name": {}}}');
+        $this->assertNull($this->resolver->resolve($schema, $error));
+    }
+
     public function testRequiredMessageMissingPropertyKey(): void
     {
         $error = $this->error('', 'required', 'email');
@@ -133,11 +140,25 @@ JSON);
         $this->assertSame('second must be >= {minimum}', $this->resolver->resolve($schema, $error));
     }
 
+    public function testTupleItemsArrayIgnoresNonSchemaEntry(): void
+    {
+        $error = $this->error('/pair/0', 'minimum', 'pair[0]');
+        $schema = $this->schema('{"properties": {"pair": {"type": "array", "items": [false]}}}');
+        $this->assertNull($this->resolver->resolve($schema, $error));
+    }
+
     public function testNumericSegmentWithoutItems(): void
     {
         $error = $this->error('/age/0', 'minimum', 'age[0]');
         // age is an integer, not an array — no `items` to descend into.
         $schema = $this->schema('{"properties": {"age": {"type": "integer"}}}');
+        $this->assertNull($this->resolver->resolve($schema, $error));
+    }
+
+    public function testObjectPropertyThatIsNotSchemaCannotBeResolved(): void
+    {
+        $error = $this->error('/age', 'minimum', 'age');
+        $schema = $this->schema('{"properties": {"age": false}}');
         $this->assertNull($this->resolver->resolve($schema, $error));
     }
 


### PR DESCRIPTION
## What changed
- Added tests for remaining JSON Schema error-mapping and resolver branch paths.
- Covered falsey/non-string/non-schema cases that were previously only line-covered.
- Adjusted `JsonSchemaErrors::getIterator()` so branch/path instrumentation records the generator path fully.

## Why
The suite already had full line coverage, but branch coverage was slightly below 100%. These changes make the branch coverage target explicit and verifiable.

## Validation
- Fetched latest `upstream/1.x` before creating this PR.
- Ran `composer coverage`.
- Result: `OK (409 tests, 709 assertions)`.
- Coverage summary: `Branches: 100.00% (1150/1150)`, `Lines: 100.00% (1453/1453)`, `Methods: 100.00% (319/319)`, `Classes: 100.00% (96/96)`.
