### PR TITLE
Fix tests failing with --prefer-lowest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,8 @@
         "bear/devtools": "^1.0",
         "koriym/json-schema-faker": "^0.3.1",
         "ray/compiler": "^1.12",
+        "koriym/php-server": "^1.0",
+        "webmozart/assert": "^2.0",
         "bamarni/composer-bin-plugin": "^1.4"
     },
     "autoload": {


### PR DESCRIPTION
## Problem

`composer update --prefer-lowest` + `composer test` produced 2 errors and 1 deprecation:

1. **Class `Koriym\PhpServer\PhpServer` not found** — `bear/devtools` 1.0.2 (the lowest version) does not depend on `koriym/php-server`, but tests use it directly.
2. **PHP 8.4 deprecation: "Use of 'static' in callables is deprecated"** — `webmozart/assert` 1.x uses `array('static', )` which is deprecated in PHP 8.4.

## Fix

- Add `koriym/php-server: ^1.0` to `require-dev`
- Pin `webmozart/assert: ^2.0` in `require-dev` (compatible with `phpdocumentor/reflection-docblock`'s `^1.9.1 || ^2` constraint)

## Verification

- ✅ `composer update --prefer-lowest --prefer-stable` + `composer test` — 403 tests, 0 errors, 0 deprecations
- ✅ `composer update` + `composer test` — 403 tests, 0 errors, 0 deprecations
- ✅ `composer cs-fix` — no violations